### PR TITLE
 Implented feed filter by title with regular expression

### DIFF
--- a/_example/etc/fm.yml
+++ b/_example/etc/fm.yml
@@ -73,6 +73,18 @@ feeds:
       - name: Большой дозор
         url: http://echo.msk.ru/programs/dozor/rss-audio.xml
 
+  echo-msk-filtered-example:
+    title: Пример фильтрации постов в фиде
+    description: Фид с фильтром на базе http://feeds.rucast.net/echomsk
+    link: http://echo.msk.ru
+    language: "ru-ru"
+    image: images/echomsk.png
+    sources:
+      - name: Правильный, фильтрованный, комбинированный фид избранных передач
+        url: http://feeds.rucast.net/echomsk
+    filter:
+      title: (Часть \d+)
+
 system:
   update: 1m
   max_per_feed: 5

--- a/app/main_test.go
+++ b/app/main_test.go
@@ -12,32 +12,43 @@ import (
 func TestLoadConfig(t *testing.T) {
 	data := []byte(`
 feeds:
- first:
-  title: "blah 1"
-  sources:
-   - name: nnn1
-     url: http://aa.com/u1
-   - name: nnn2
-     url: http://aa.com/u2
+  first:
+    title: "blah 1"
+    sources:
+      - name: nnn1
+        url: http://aa.com/u1
+      - name: nnn2
+        url: http://aa.com/u2
 
- second:
-  title: "blah 2"
-  description: "some 2"
-  sources:
-   - name: mmm1
-     url: https://bbb.com/u1
+  second:
+    title: "blah 2"
+    description: "some 2"
+    sources:
+      - name: mmm1
+        url: https://bbb.com/u1
+
+  filtered:
+    title: "filtered 1"
+    description: "filtered"
+    sources:
+      - name: mmm1
+        url: https://filtered.feed
+    filter:
+      title: ^filterme*
 
 update: 600
+
 `)
 
 	assert.Nil(t, ioutil.WriteFile("/tmp/fm.yml", data, 0777), "failed write yml") // nolint
 
 	r, err := loadConfig("/tmp/fm.yml")
 	assert.Nil(t, err)
-	assert.Equal(t, 2, len(r.Feeds), "2 sets")
+	assert.Equal(t, 3, len(r.Feeds), "3 sets")
 	assert.Equal(t, 2, len(r.Feeds["first"].Sources), "2 feeds in first")
 	assert.Equal(t, 1, len(r.Feeds["second"].Sources), "1 feed in second")
 	assert.Equal(t, "https://bbb.com/u1", r.Feeds["second"].Sources[0].URL)
+	assert.Equal(t, "^filterme*", r.Feeds["filtered"].Filter.Title)
 }
 
 func TestLoadConfigNotFoundFile(t *testing.T) {

--- a/app/proc/processor_test.go
+++ b/app/proc/processor_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/umputun/feed-master/app/feed"
 )
 
 func TestSetDefault(t *testing.T) {
@@ -26,4 +27,18 @@ func TestSetDefault(t *testing.T) {
 	}
 
 	assert.EqualValues(t, expectedConf.System, p.Conf.System)
+}
+
+func TestFilter(t *testing.T) {
+	feedItem := feed.Item{Title: "Foo Bar (Part 1)"}
+	filter := Filter{Title: "(Part \\d+)"}
+	result, _ := filter.skip(feedItem)
+	assert.True(t, result)
+}
+
+func TestBlankFilter(t *testing.T) {
+	feedItem := feed.Item{Title: "Foo Bar (Part 1)"}
+	filter := Filter{}
+	result, _ := filter.skip(feedItem)
+	assert.False(t, result)
 }

--- a/app/proc/telegram_test.go
+++ b/app/proc/telegram_test.go
@@ -203,7 +203,7 @@ func TestGetContentLengthIfErrorConnect(t *testing.T) {
 	length, err := getContentLength(ts.URL)
 
 	assert.Equal(t, length, 0)
-	assert.EqualError(t, err, fmt.Sprintf("can't HEAD %s: Head %q: EOF", ts.URL, ts.URL))
+	assert.EqualError(t, err, fmt.Sprintf("can't HEAD %s: Head %s: EOF", ts.URL, ts.URL))
 }
 
 func TestDownloadAudioIfRequestError(t *testing.T) {
@@ -218,7 +218,7 @@ func TestDownloadAudioIfRequestError(t *testing.T) {
 	got, err := client.downloadAudio(ts.URL)
 
 	assert.Nil(t, got)
-	assert.EqualError(t, err, fmt.Sprintf("Get %q: EOF", ts.URL))
+	assert.EqualError(t, err, fmt.Sprintf("Get %s: EOF", ts.URL))
 }
 
 func TestDownloadAudio(t *testing.T) {

--- a/app/proc/telegram_test.go
+++ b/app/proc/telegram_test.go
@@ -64,7 +64,7 @@ func TestSendIfContentLengthZero(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Header().Set("Content-Length", string(0))
+		w.Header().Set("Content-Length", fmt.Sprint(0))
 	}))
 	defer ts.Close()
 
@@ -174,7 +174,7 @@ func TestGetContentLengthNotFound(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(tc.statusCode)
-				w.Header().Set("Content-Length", string(tc.contentLength))
+				w.Header().Set("Content-Length", fmt.Sprint(tc.contentLength))
 				if tc.contentLength > 0 {
 					fmt.Fprint(w, "abcd")
 				}
@@ -203,7 +203,7 @@ func TestGetContentLengthIfErrorConnect(t *testing.T) {
 	length, err := getContentLength(ts.URL)
 
 	assert.Equal(t, length, 0)
-	assert.EqualError(t, err, fmt.Sprintf("can't HEAD %s: Head %s: EOF", ts.URL, ts.URL))
+	assert.EqualError(t, err, fmt.Sprintf("can't HEAD %s: Head %q: EOF", ts.URL, ts.URL))
 }
 
 func TestDownloadAudioIfRequestError(t *testing.T) {
@@ -218,13 +218,13 @@ func TestDownloadAudioIfRequestError(t *testing.T) {
 	got, err := client.downloadAudio(ts.URL)
 
 	assert.Nil(t, got)
-	assert.EqualError(t, err, fmt.Sprintf("Get %s: EOF", ts.URL))
+	assert.EqualError(t, err, fmt.Sprintf("Get %q: EOF", ts.URL))
 }
 
 func TestDownloadAudio(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Header().Set("Content-Length", string(4))
+		w.Header().Set("Content-Length", fmt.Sprint(4))
 		fmt.Fprint(w, "abcd")
 	}))
 	defer ts.Close()


### PR DESCRIPTION
additional fixed build errors: `conversion from untyped int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)` in **telegram_test.go**