### PR TITLE
Implented feed filter by title with regular expression

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: set up go 1.13
+      - name: set up go 1.15
         uses: actions/setup-go@v1
         with:
-          go-version: 1.13
+          go-version: 1.15
         id: go
 
       - name: checkout

--- a/_example/etc/fm.yml
+++ b/_example/etc/fm.yml
@@ -73,6 +73,18 @@ feeds:
       - name: Большой дозор
         url: http://echo.msk.ru/programs/dozor/rss-audio.xml
 
+  echo-msk-filtered-example:
+    title: Пример фильтрации постов в фиде
+    description: Фид с фильтром на базе http://feeds.rucast.net/echomsk
+    link: http://echo.msk.ru
+    language: "ru-ru"
+    image: images/echomsk.png
+    sources:
+      - name: Правильный, фильтрованный, комбинированный фид избранных передач
+        url: http://feeds.rucast.net/echomsk
+    filter:
+      title: (Часть \d+)
+
 system:
   update: 1m
   max_per_feed: 5

--- a/app/api/server.go
+++ b/app/api/server.go
@@ -84,7 +84,7 @@ func (s *Server) Run(port int) {
 // GET /rss/{name} - returns rss for given feeds set
 func (s *Server) getFeedCtrl(w http.ResponseWriter, r *http.Request) {
 	feedName := chi.URLParam(r, "name")
-	items, err := s.Store.Load(feedName, s.Conf.System.MaxTotal)
+	items, err := s.Store.Load(feedName, s.Conf.System.MaxTotal, true)
 	if err != nil {
 		rest.SendErrorJSON(w, r, log.Default(), http.StatusBadRequest, err, "failed to get feed")
 		return

--- a/app/api/web.go
+++ b/app/api/web.go
@@ -23,7 +23,7 @@ func (s *Server) getFeedPageCtrl(w http.ResponseWriter, r *http.Request) {
 	feedName := chi.URLParam(r, "name")
 
 	data, err := s.cache.Get(feedName, func() (lcw.Value, error) {
-		items, err := s.Store.Load(feedName, s.Conf.System.MaxTotal)
+		items, err := s.Store.Load(feedName, s.Conf.System.MaxTotal, false)
 		if err != nil {
 			return nil, err
 		}

--- a/app/feed/parser.go
+++ b/app/feed/parser.go
@@ -46,7 +46,8 @@ type Item struct {
 	GUID      string        `xml:"guid"`
 
 	// Internal
-	DT time.Time `xml:"-"`
+	DT   time.Time `xml:"-"`
+	Junk bool      `xml:"-"`
 }
 
 // Enclosure element from item

--- a/app/main_test.go
+++ b/app/main_test.go
@@ -12,32 +12,43 @@ import (
 func TestLoadConfig(t *testing.T) {
 	data := []byte(`
 feeds:
- first:
-  title: "blah 1"
-  sources:
-   - name: nnn1
-     url: http://aa.com/u1
-   - name: nnn2
-     url: http://aa.com/u2
+  first:
+    title: "blah 1"
+    sources:
+      - name: nnn1
+        url: http://aa.com/u1
+      - name: nnn2
+        url: http://aa.com/u2
 
- second:
-  title: "blah 2"
-  description: "some 2"
-  sources:
-   - name: mmm1
-     url: https://bbb.com/u1
+  second:
+    title: "blah 2"
+    description: "some 2"
+    sources:
+      - name: mmm1
+        url: https://bbb.com/u1
+
+  filtered:
+    title: "filtered 1"
+    description: "filtered"
+    sources:
+      - name: mmm1
+        url: https://filtered.feed
+    filter:
+      title: ^filterme*
 
 update: 600
+
 `)
 
 	assert.Nil(t, ioutil.WriteFile("/tmp/fm.yml", data, 0777), "failed write yml") // nolint
 
 	r, err := loadConfig("/tmp/fm.yml")
 	assert.Nil(t, err)
-	assert.Equal(t, 2, len(r.Feeds), "2 sets")
+	assert.Equal(t, 3, len(r.Feeds), "3 sets")
 	assert.Equal(t, 2, len(r.Feeds["first"].Sources), "2 feeds in first")
 	assert.Equal(t, 1, len(r.Feeds["second"].Sources), "1 feed in second")
 	assert.Equal(t, "https://bbb.com/u1", r.Feeds["second"].Sources[0].URL)
+	assert.Equal(t, "^filterme*", r.Feeds["filtered"].Filter.Title)
 }
 
 func TestLoadConfigNotFoundFile(t *testing.T) {

--- a/app/proc/processor.go
+++ b/app/proc/processor.go
@@ -160,6 +160,7 @@ func (filter *Filter) skip(item feed.Item) (bool, error) {
 	if filter.Title != "" {
 		matched, err := regexp.MatchString(filter.Title, item.Title)
 		if err != nil {
+			log.Printf("[WARN] wrong title's regular expression: %s", filter.Title)
 			return matched, err
 		}
 		if matched {

--- a/app/proc/processor_test.go
+++ b/app/proc/processor_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/umputun/feed-master/app/feed"
 )
 
 func TestSetDefault(t *testing.T) {
@@ -26,4 +27,18 @@ func TestSetDefault(t *testing.T) {
 	}
 
 	assert.EqualValues(t, expectedConf.System, p.Conf.System)
+}
+
+func TestFilter(t *testing.T) {
+	feedItem := feed.Item{Title: "Foo Bar (Part 1)"}
+	filter := Filter{Title: "(Part \\d+)"}
+	result, _ := filter.skip(feedItem)
+	assert.True(t, result)
+}
+
+func TestBlankFilter(t *testing.T) {
+	feedItem := feed.Item{Title: "Foo Bar (Part 1)"}
+	filter := Filter{}
+	result, _ := filter.skip(feedItem)
+	assert.False(t, result)
 }

--- a/app/proc/processor_test.go
+++ b/app/proc/processor_test.go
@@ -42,3 +42,10 @@ func TestBlankFilter(t *testing.T) {
 	result, _ := filter.skip(feedItem)
 	assert.False(t, result)
 }
+
+func TestErrorFilter(t *testing.T) {
+	feedItem := feed.Item{Title: "Foo Bar (Part 1)"}
+	filter := Filter{"("}
+	result, _ := filter.skip(feedItem)
+	assert.False(t, result)
+}

--- a/app/proc/store.go
+++ b/app/proc/store.go
@@ -82,7 +82,7 @@ func (b BoltDB) Save(fmFeed string, item feed.Item) (bool, error) {
 }
 
 // Load from bold for given feed, up to max
-func (b BoltDB) Load(fmFeed string, max int) ([]feed.Item, error) {
+func (b BoltDB) Load(fmFeed string, max int, skipJunk bool) ([]feed.Item, error) {
 	result := []feed.Item{}
 
 	err := b.DB.View(func(tx *bolt.Tx) error {
@@ -95,6 +95,9 @@ func (b BoltDB) Load(fmFeed string, max int) ([]feed.Item, error) {
 			item := feed.Item{}
 			if err := json.Unmarshal(v, &item); err != nil {
 				log.Printf("[WARN] failed to unmarshal, %v", err)
+				continue
+			}
+			if skipJunk && item.Junk {
 				continue
 			}
 			if len(result) >= max {

--- a/app/proc/store_test.go
+++ b/app/proc/store_test.go
@@ -86,7 +86,7 @@ func TestLoadIfNotBucket(t *testing.T) {
 	defer os.Remove(tmpfile.Name())
 	boltDB, _ := NewBoltDB(tmpfile.Name())
 
-	feedItems, err := boltDB.Load("100500", 5)
+	feedItems, err := boltDB.Load("100500", 5, false)
 
 	assert.Equal(t, len(feedItems), 0)
 	assert.EqualError(t, err, "no bucket for 100500")
@@ -100,7 +100,7 @@ func TestLoad(t *testing.T) {
 	_, err := boltDB.Save("radio-t", feed.Item{PubDate: pubDate})
 	require.NoError(t, err)
 
-	items, err := boltDB.Load("radio-t", 5)
+	items, err := boltDB.Load("radio-t", 5, false)
 
 	assert.Nil(t, err)
 	assert.Equal(t, 1, len(items))
@@ -134,7 +134,7 @@ func TestLoadChackMax(t *testing.T) {
 		i := i
 		tc := tc
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			items, err := boltDB.Load("radio-t", tc.max)
+			items, err := boltDB.Load("radio-t", tc.max, false)
 
 			assert.Nil(t, err)
 			assert.Equal(t, tc.count, len(items))

--- a/app/proc/telegram_test.go
+++ b/app/proc/telegram_test.go
@@ -64,7 +64,7 @@ func TestSendIfContentLengthZero(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Header().Set("Content-Length", string(0))
+		w.Header().Set("Content-Length", fmt.Sprint(0))
 	}))
 	defer ts.Close()
 
@@ -174,7 +174,7 @@ func TestGetContentLengthNotFound(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(tc.statusCode)
-				w.Header().Set("Content-Length", string(tc.contentLength))
+				w.Header().Set("Content-Length", fmt.Sprint(tc.contentLength))
 				if tc.contentLength > 0 {
 					fmt.Fprint(w, "abcd")
 				}
@@ -224,7 +224,7 @@ func TestDownloadAudioIfRequestError(t *testing.T) {
 func TestDownloadAudio(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Header().Set("Content-Length", string(4))
+		w.Header().Set("Content-Length", fmt.Sprint(4))
 		fmt.Fprint(w, "abcd")
 	}))
 	defer ts.Close()

--- a/app/proc/telegram_test.go
+++ b/app/proc/telegram_test.go
@@ -64,7 +64,7 @@ func TestSendIfContentLengthZero(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
-		w.Header().Set("Content-Length", fmt.Sprint(0))
+		w.Header().Set("Content-Length", "0")
 	}))
 	defer ts.Close()
 
@@ -174,7 +174,7 @@ func TestGetContentLengthNotFound(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(tc.statusCode)
-				w.Header().Set("Content-Length", fmt.Sprint(tc.contentLength))
+				w.Header().Set("Content-Length", strconv.Itoa(tc.contentLength))
 				if tc.contentLength > 0 {
 					fmt.Fprint(w, "abcd")
 				}

--- a/app/proc/telegram_test.go
+++ b/app/proc/telegram_test.go
@@ -224,7 +224,7 @@ func TestDownloadAudioIfRequestError(t *testing.T) {
 func TestDownloadAudio(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
-		w.Header().Set("Content-Length", fmt.Sprint(4))
+		w.Header().Set("Content-Length", "4")
 		fmt.Fprint(w, "abcd")
 	}))
 	defer ts.Close()

--- a/app/proc/telegram_test.go
+++ b/app/proc/telegram_test.go
@@ -203,7 +203,7 @@ func TestGetContentLengthIfErrorConnect(t *testing.T) {
 	length, err := getContentLength(ts.URL)
 
 	assert.Equal(t, length, 0)
-	assert.EqualError(t, err, fmt.Sprintf("can't HEAD %s: Head %s: EOF", ts.URL, ts.URL))
+	assert.EqualError(t, err, fmt.Sprintf("can't HEAD %s: Head %q: EOF", ts.URL, ts.URL))
 }
 
 func TestDownloadAudioIfRequestError(t *testing.T) {
@@ -218,7 +218,7 @@ func TestDownloadAudioIfRequestError(t *testing.T) {
 	got, err := client.downloadAudio(ts.URL)
 
 	assert.Nil(t, got)
-	assert.EqualError(t, err, fmt.Sprintf("Get %s: EOF", ts.URL))
+	assert.EqualError(t, err, fmt.Sprintf("Get %q: EOF", ts.URL))
 }
 
 func TestDownloadAudio(t *testing.T) {

--- a/app/webapp/static/styles.css
+++ b/app/webapp/static/styles.css
@@ -223,6 +223,10 @@ nav {
     color: rgba(10, 107, 165, 0.87)
 }
 
+.junk-row .ump-feed-master-program-name {
+    color: rgba(140, 140, 140, 0.87)
+}
+
 .ump-feed-master__data-row-info-cell {
     flex: 1;
     padding-left: 0.75rem;
@@ -257,6 +261,15 @@ nav {
     color: #0473b4;
 }
 
+.junk-row .fa-volume-up {
+    color: #666666;
+}
+
 .fa-info-circle {
     color: rgba(4, 115, 180, 0.4);
+}
+
+.junk-row 
+.fa-info-circle {
+    color: rgba(70, 70, 70, 0.4);
 }

--- a/app/webapp/templates/feed.tmpl
+++ b/app/webapp/templates/feed.tmpl
@@ -34,7 +34,11 @@
 
 <main class="ump-feed-master">
     {{range .Items}}
+    {{if .Junk}}
+    <div class="ump-feed-master__data-row junk-row">
+    {{else}}
     <div class="ump-feed-master__data-row">
+    {{end}}
         <div class="ump-feed-master__data-row-player-cell">
             <a href="{{.Enclosure.URL}}" target="_blank">
                 <i class="fas fa-volume-up"></i>
@@ -50,7 +54,14 @@
                     </i>
                 </a>
             </div>
-            <div class="ump-feed-master-timestamp-cell">{{.DT.Format "02 Jan 15:04"}}</div>
+            <div class="ump-feed-master-timestamp-cell">
+                {{if .Junk}}
+                <i class="fas fa-exclamation-circle"
+                   data-toggle="tooltip"
+                   title="Junk - excluded from target rss feed">
+                </i>
+                {{end}}
+                {{.DT.Format "02 Jan 15:04"}}</div>
         </div>
     </div>
     {{end}}


### PR DESCRIPTION
Additionally fixed build errors: `conversion from untyped int to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)` in  **telegram_test.go**