### PR TITLE
Revert processed items in the RSS feed to keep order

### DIFF
--- a/app/proc/processor.go
+++ b/app/proc/processor.go
@@ -94,6 +94,14 @@ func (p *Processor) Do() {
 	}
 }
 
+// reverse slice of items in-place, necessary to post oldest entries first
+func (p *Processor) reverse(items []feed.Item) {
+	last := len(items) - 1
+	for i := 0; i < len(items)/2; i++ {
+		items[i], items[last-i] = items[last-i], items[i]
+	}
+}
+
 func (p *Processor) feed(name, url, telegramChannel string, max int, filter Filter) {
 	rss, err := feed.Parse(url)
 	if err != nil {
@@ -107,6 +115,8 @@ func (p *Processor) feed(name, url, telegramChannel string, max int, filter Filt
 		upto = len(rss.ItemList)
 	}
 
+	// reverse last entries to upload oldest first
+	p.reverse(rss.ItemList[:upto])
 	for _, item := range rss.ItemList[:upto] {
 		// skip 1y and older
 		if item.DT.Before(time.Now().AddDate(-1, 0, 0)) {

--- a/app/proc/processor_test.go
+++ b/app/proc/processor_test.go
@@ -67,3 +67,12 @@ func TestFilterAllCases(t *testing.T) {
 		})
 	}
 }
+
+func TestReverse(t *testing.T) {
+	p := Processor{
+		Conf: &Conf{},
+	}
+	items := []feed.Item{{Title: "1"}, {Title: "2"}}
+	p.reverse(items)
+	assert.Equal(t, items, []feed.Item{{Title: "2"}, {Title: "1"}})
+}


### PR DESCRIPTION
That way, the oldest entry from the newly processed feed will be sent to Telegram and Twitter first, while before that commit it's the opposite, newest first.

It's part of #37 which doesn't belong there.