### PR TITLE
Don't rely on RSS item length, fetching it instead

### DIFF
--- a/app/proc/telegram.go
+++ b/app/proc/telegram.go
@@ -58,11 +58,9 @@ func (client TelegramClient) Send(channelID string, item feed.Item) (err error) 
 		return nil
 	}
 
-	contentLength := item.Enclosure.Length
-	if contentLength <= 0 {
-		if contentLength, err = getContentLength(item.Enclosure.URL); err != nil {
-			return errors.Wrapf(err, "can't get length for %s", item.Enclosure.URL)
-		}
+	var contentLength int
+	if contentLength, err = getContentLength(item.Enclosure.URL); err != nil {
+		return errors.Wrapf(err, "can't get length for %s", item.Enclosure.URL)
 	}
 
 	var message *tb.Message
@@ -81,7 +79,7 @@ func (client TelegramClient) Send(channelID string, item feed.Item) (err error) 
 	return nil
 }
 
-// getContentLength uses HEAD request and called as a fallback in case of item.Enclosure.Length not populated
+// getContentLength uses HEAD request to retrieve length of the provided URL
 func getContentLength(url string) (int, error) {
 	resp, err := http.Head(url) // nolint:gosec // URL considered safe
 	if err != nil {

--- a/app/proc/telegram_test.go
+++ b/app/proc/telegram_test.go
@@ -68,12 +68,7 @@ func TestSendIfContentLengthZero(t *testing.T) {
 	}))
 	defer ts.Close()
 
-	err := client.Send("100500", feed.Item{
-		Enclosure: feed.Enclosure{
-			URL:    ts.URL,
-			Length: 0,
-		},
-	})
+	err := client.Send("100500", feed.Item{Enclosure: feed.Enclosure{URL: ts.URL}})
 
 	assert.Error(t, err)
 	assert.EqualError(t, err, fmt.Sprintf("can't get length for %s: non-200 status, 500", ts.URL))


### PR DESCRIPTION
RSS item length is not reliable and HEAD requests are, that PR stops feed-master from relying on RSS data altogether.