### PR TITLE
Improve telegram messages formatting, add tests

### DIFF
--- a/app/proc/telegram_test.go
+++ b/app/proc/telegram_test.go
@@ -100,6 +100,56 @@ func TestTagLinkOnlySupport(t *testing.T) {
 	assert.Equal(t, htmlExpected, got, "support only html tag a")
 }
 
+func TestFormattedMessage(t *testing.T) {
+	client := TelegramClient{}
+	cases := []struct {
+		item         feed.Item
+		expectedHTML string
+	}{
+		{item: feed.Item{}, expectedHTML: ""},
+		{item: feed.Item{Description: "plain text", Title: "test title"}, expectedHTML: "test title\n\nplain text"},
+		{
+			item: feed.Item{
+				Description: `<![CDATA[<p><img src="https://podcast.umputun.com/images/uwp/uwp463.jpg" alt=""></p>
+<ul>
+<li>Дела рабочие.</li>
+<li>Цепная реакция в деле "умного дома".</li>
+<li>Снегопад помешал собачьему дню.</li>
+<li>Судорожные поиски аккумулятора и капризность хонды.</li>
+<li>Вопросы и ответы</li>
+</ul>
+<p><a href="https://podcast.umputun.com/media/ump_podcast463.mp3">аудио</a></p>
+<audio src="https://podcast.umputun.com/media/ump_podcast463.mp3" preload="none"></audio>]]>`},
+			expectedHTML: "Дела рабочие.\nЦепная реакция в деле \"умного дома\".\nСнегопад помешал собачьему дню.\nСудорожные поиски аккумулятора и капризность хонды.\nВопросы и ответы\n\n<a href=\"https://podcast.umputun.com/media/ump_podcast463.mp3\">аудио</a>",
+		},
+		{
+			item: feed.Item{
+				Title: "Код доступа : Юлия Латынина",
+				Link:  "https://echo.msk.ru/programs/code/2868346-echo/",
+				Description: `&lt;img align=&quot;left&quot; width=&quot;50&quot; height=&quot;50&quot; alt=&quot;&quot; title=&quot;&quot; src=&quot;https://echo.msk.ru/files/avatar_s/783858.jpg&quot; /&gt;
+ &lt;p&gt;Ведущие:
+
+   &lt;a href=&quot;https://echo.msk.ru/contributors/324/&quot;&gt;Юлия Латынина&lt;/a&gt;
+ &lt;/p&gt;
+&lt;p&gt;Есть резиновая кукла под названием Явлинский, которую надувает Кириенко. И есть системная кампания Кремля. Вот заказчик — Путин, организатор — Кириенко, а исполнителей, имя им — легион. Это компания по уничтожению сентябрьских выборов и «Умного голосования»...&lt;/p&gt;`,
+				Enclosure: feed.Enclosure{
+					URL: "https://echo.msk.ru/programs/code/2868346-echo/",
+				},
+			},
+			expectedHTML: "<a href=\"https://echo.msk.ru/programs/code/2868346-echo/\">Код доступа : Юлия Латынина</a>\n\nВедущие:\n\n   <a href=\"https://echo.msk.ru/contributors/324/\">Юлия Латынина</a>\n \nЕсть резиновая кукла под названием Явлинский, которую надувает Кириенко. И есть системная кампания Кремля. Вот заказчик — Путин, организатор — Кириенко, а исполнителей, имя им — легион. Это компания по уничтожению сентябрьских выборов и «Умного голосования»...",
+		},
+	}
+
+	for i, tc := range cases {
+		i := i
+		tc := tc
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
+			htmlMessage := client.getMessageHTML(tc.item, false)
+			assert.Equal(t, tc.expectedHTML, htmlMessage)
+		})
+	}
+}
+
 func TestGetMessageHTML(t *testing.T) {
 	item := feed.Item{
 		Title:       "\tPodcast\n\t",


### PR DESCRIPTION
Before HTML stripping of all tags but `<a>` didn't work properly which resulted in messages cut after first non-`<a>` tag, after this change message generator, is more sophisticated about different kinds of RSS items and handles HTML sanitizing properly.
Before:
<img width="460" alt="image" src="https://user-images.githubusercontent.com/712534/125693658-15cf34eb-7cee-468b-8533-97083e218e20.png">
After:
<img width="639" alt="image" src="https://user-images.githubusercontent.com/712534/125693778-2e50c4c9-abe7-417b-9ece-2855e145d829.png">
