### PR TITLE
Add local bot server usage, increase file upload limit from 50Mb to 2000Mb

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Pulls multiple podcast feeds (RSS) and republishes as a common feed, properly so
 
 - Copy `docker-compose.yml` and adjust exposed port if needed
 - Create `etc/fm.yml` (sample provided in `_example`)
-- Start container with `docker-compose up -d`
+- Start container with `docker-compose up -d feed-master`
 
 ### Application parameters
 
@@ -17,6 +17,7 @@ Pulls multiple podcast feeds (RSS) and republishes as a common feed, properly so
 | feed             | FM_FEED           |                 | single feed, overrides config             |
 | update-interval  | UPDATE_INTERVAL   | `1m`            | update interval, overrides config         |
 | telegram_chan    | TELEGRAM_CHAN     |                 | single telegram channel, overrides config |
+| telegram_server  | TELEGRAM_SERVER   | `https://api.telegram.org` | telegram bot api server        |
 | telegram_token   | TELEGRAM_TOKEN    |                 | telegram token           |
 | telegram_timeout | TELEGRAM_TIMEOUT  | `1m`            | telegram timeout         |
 | consumer-key     | TWI_CONSUMER_KEY  |                 | twitter consumer key     |
@@ -34,3 +35,11 @@ Pulls multiple podcast feeds (RSS) and republishes as a common feed, properly so
 ## Web UI
 
 Web UI shows a list of items from generated RSS. It is available on `/feed/{name}`
+
+## Telegram notifications
+
+By default, (with only `TELEGRAM_TOKEN` provided) Telegram notifications will be sent using standard Bot API which has a limit of [50Mb](https://core.telegram.org/bots/api#sending-files) for audio file upload.
+
+You can provide `TELEGRAM_API_ID` and `TELEGRAM_API_HASH` (from [here](https://my.telegram.org/apps)) to `telegram-bot-api` service in docker-compose.yml and uncomment `TELEGRAM_SERVER` for `feed-master`, then it would use the local bot api server to raise audio file upload limit from 50Mb [to 2000Mb](https://core.telegram.org/bots/api#using-a-local-bot-api-server).
+
+To use local telegram bot api server, use `docker-compose up -d` command instead of `docker-compose up -d feed-master`.

--- a/app/main.go
+++ b/app/main.go
@@ -27,6 +27,7 @@ type options struct {
 	TelegramChannel string        `long:"telegram_chan" env:"TELEGRAM_CHAN" description:"single telegram channel, overrides config"`
 	UpdateInterval  time.Duration `long:"update-interval" env:"UPDATE_INTERVAL" default:"1m" description:"update interval, overrides config"`
 
+	TelegramServer        string        `long:"telegram_server" env:"TELEGRAM_SERVER" default:"https://api.telegram.org" description:"telegram bot api server"`
 	TelegramToken         string        `long:"telegram_token" env:"TELEGRAM_TOKEN" description:"telegram token"`
 	TelegramTimeout       time.Duration `long:"telegram_timeout" env:"TELEGRAM_TIMEOUT" default:"1m" description:"telegram timeout"`
 	TwitterConsumerKey    string        `long:"consumer-key" env:"TWI_CONSUMER_KEY" description:"twitter consumer key"`
@@ -66,7 +67,7 @@ func main() {
 		log.Fatalf("[ERROR] can't open db %s, %v", opts.DB, err)
 	}
 
-	telegramNotif, err := proc.NewTelegramClient(opts.TelegramToken, opts.TelegramTimeout)
+	telegramNotif, err := proc.NewTelegramClient(opts.TelegramToken, opts.TelegramServer, opts.TelegramTimeout)
 	if err != nil {
 		log.Fatalf("[ERROR] failed to initialize telegram client %s, %v", opts.TelegramToken, err)
 	}

--- a/app/proc/telegram_test.go
+++ b/app/proc/telegram_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestNewTelegramClientIfTokenEmpty(t *testing.T) {
-	client, err := NewTelegramClient("", 0)
+	client, err := NewTelegramClient("", "", 0)
 	assert.NoError(t, err)
 	assert.Nil(t, client.Bot)
 }
@@ -34,7 +34,7 @@ func TestNewTelegramClientCheckTimeout(t *testing.T) {
 		i := i
 		tt := tt
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			client, err := NewTelegramClient("", tt.timeout)
+			client, err := NewTelegramClient("", "", tt.timeout)
 			assert.NoError(t, err)
 			assert.Equal(t, tt.expected, client.Timeout)
 		})
@@ -42,7 +42,7 @@ func TestNewTelegramClientCheckTimeout(t *testing.T) {
 }
 
 func TestSendIfBotIsNil(t *testing.T) {
-	client, err := NewTelegramClient("", 0)
+	client, err := NewTelegramClient("", "", 0)
 	require.NoError(t, err)
 	err = client.Send("@channel", feed.Item{})
 	assert.NoError(t, err)
@@ -55,23 +55,6 @@ func TestSendIfChannelIDEmpty(t *testing.T) {
 
 	err := client.Send("", feed.Item{})
 	assert.NoError(t, err)
-}
-
-func TestSendIfContentLengthZero(t *testing.T) {
-	client := TelegramClient{
-		Bot: &tb.Bot{},
-	}
-
-	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-		w.Header().Set("Content-Length", "0")
-	}))
-	defer ts.Close()
-
-	err := client.Send("100500", feed.Item{Enclosure: feed.Enclosure{URL: ts.URL}})
-
-	assert.Error(t, err)
-	assert.EqualError(t, err, fmt.Sprintf("can't get length for %s: non-200 status, 500", ts.URL))
 }
 
 func TestTagLinkOnlySupport(t *testing.T) {
@@ -199,56 +182,6 @@ func TestGetFilenameByURL(t *testing.T) {
 			assert.Equal(t, tt.expected, fname)
 		})
 	}
-}
-
-func TestGetContentLengthNotFound(t *testing.T) {
-	cases := []struct {
-		statusCode     int
-		contentLength  int
-		expectedLength int
-		expectedError  string
-	}{
-		{http.StatusInternalServerError, 100500, 0, "non-200 status, 500"},
-		{http.StatusMethodNotAllowed, 100500, 0, "non-200 status, 405"},
-		{http.StatusOK, 4, 4, ""},
-	}
-
-	for i, tc := range cases {
-		i := i
-		tc := tc
-		t.Run(strconv.Itoa(i), func(t *testing.T) {
-			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(tc.statusCode)
-				w.Header().Set("Content-Length", strconv.Itoa(tc.contentLength))
-				if tc.contentLength > 0 {
-					fmt.Fprint(w, "abcd")
-				}
-			}))
-
-			defer ts.Close()
-
-			length, err := getContentLength(ts.URL)
-
-			assert.Equal(t, tc.expectedLength, length)
-			if err != nil {
-				assert.EqualError(t, err, tc.expectedError)
-			}
-		})
-	}
-}
-
-func TestGetContentLengthIfErrorConnect(t *testing.T) {
-	var ts *httptest.Server
-	ts = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ts.CloseClientConnections()
-	}))
-
-	defer ts.Close()
-
-	length, err := getContentLength(ts.URL)
-
-	assert.Equal(t, length, 0)
-	assert.EqualError(t, err, fmt.Sprintf("can't HEAD %s: Head %q: EOF", ts.URL, ts.URL))
 }
 
 func TestDownloadAudioIfRequestError(t *testing.T) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,16 @@
 version: "2"
 
+volumes:
+    server-data:
+        driver: local
+
 services:
     feed-master:
         build:
             context: .
             dockerfile: Dockerfile
             args:
-            - SKIP_TEST
+                - SKIP_TEST
         image: umputun/feed-master:master
         container_name: feed-master
         hostname: feed-master
@@ -24,9 +28,34 @@ services:
             - FM_DB=/srv/var/feed-master.bdb
             - FM_CONF=/srv/etc/fm.yml
             - TELEGRAM_TOKEN
+        # Uncomment the line below if you want to enable Telegram
+        # with file upload limit raised from default 50Mb to 2000Mb
+        #   - TELEGRAM_SERVER=http://telegram-bot-api:8081
         volumes:
             - ./var:/srv/var # mapped location to save status
             - ./_example/etc:/srv/etc # mapped location for config
             - ./_example/images:/srv/images # mapped location for images
         ports:
             - "8097:8080" # exposed on port 8097
+
+    # This service is optional.
+    # It could be accessed by port 8081 as local Telegram Bot API server.
+    telegram-bot-api:
+        image: ghcr.io/bots-house/docker-telegram-bot-api:latest
+        container_name: telegram-bot-api
+        hostname: telegram-bot-api
+        command: "--dir=/var/lib/telegram-bot-api"
+        volumes:
+            - server-data:/var/lib/telegram-bot-api
+        restart: unless-stopped
+
+        logging:
+            driver: json-file
+            options:
+                max-size: "10m"
+                max-file: "5"
+
+        environment:
+            # get these values from https://core.telegram.org/api/obtaining_api_id
+            - TELEGRAM_API_ID
+            - TELEGRAM_API_HASH


### PR DESCRIPTION
As kindly suggested by @ernado [here](https://github.com/umputun/feed-master/pull/37#issuecomment-879079824), increase file upload limit from 50Mb to 2000Mb by allowing to use of [local telegram bot API](https://core.telegram.org/bots/api#using-a-local-bot-api-server) server.

It resolves #23 and likely closes #31.