### PR TITLE
Make TestFeedParse work offline, improve test

### DIFF
--- a/app/feed/parser.go
+++ b/app/feed/parser.go
@@ -111,8 +111,8 @@ func Parse(uri string) (result Rss2, err error) {
 		return result, err
 	}
 
-	result, e := parseFeedContent(b.Bytes())
-	if e != nil {
+	result, err = parseFeedContent(b.Bytes())
+	if err != nil {
 		return Rss2{}, errors.Wrap(err, "parsing error")
 	}
 

--- a/app/feed/parser_test.go
+++ b/app/feed/parser_test.go
@@ -3,7 +3,6 @@ package feed
 import (
 	"fmt"
 	"html/template"
-	"log"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -14,9 +13,81 @@ import (
 )
 
 func TestFeedParse(t *testing.T) {
-	r, err := Parse("http://feeds.rucast.net/radio-t")
-	assert.Nil(t, err)
-	log.Printf("%+v", r.ItemList[0])
+	const testFeed = `
+<?xml version="1.0" encoding="UTF-8"?>
+<rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" xmlns:media="http://search.yahoo.com/mrss/" version="2.0">
+  <channel>
+    <title>Радио-Т</title>
+    <link>https://radio-t.com</link>
+    <language>ru</language>
+    <copyright>Creative Commons - Attribution, Noncommercial, No Derivative Works 3.0 License.</copyright>
+    <itunes:author>Umputun, Bobuk, Gray, Ksenks, Alek.sys</itunes:author>
+    <itunes:subtitle>Еженедельные импровизации на хай–тек темы</itunes:subtitle>
+    <description>Разговоры на темы хайтек, высоких компьютерных технологий, гаджетов, облаков, программирования и прочего интересного из мира ИТ.</description>
+    <itunes:explicit>no</itunes:explicit>
+    <itunes:image href="https://radio-t.com/images/cover.jpg" />
+    <itunes:keywords>hitech,russian,radiot,tech,news,радио</itunes:keywords>
+    <atom10:link xmlns:atom10="http://www.w3.org/2005/Atom" rel="self" type="application/rss+xml" href="http://feeds.rucast.net/radio-t" /><feedburner:info xmlns:feedburner="http://rssnamespace.org/feedburner/ext/1.0" uri="radio-t" /><atom10:link xmlns:atom10="http://www.w3.org/2005/Atom" rel="hub" href="http://pubsubhubbub.appspot.com/" /><media:copyright>Creative Commons - Attribution, Noncommercial, No Derivative Works 3.0 License.</media:copyright><media:thumbnail url="https://radio-t.com/images/cover.jpg" /><media:keywords>hitech,russian,radiot,tech,news,радио</media:keywords><media:category scheme="http://www.itunes.com/dtds/podcast-1.0.dtd">Technology/Tech News</media:category><media:category scheme="http://www.itunes.com/dtds/podcast-1.0.dtd">Technology/Gadgets</media:category><itunes:owner><itunes:email>podcast@radio-t.com</itunes:email><itunes:name>Umputun, Bobuk, Gray, Ksenks, Alek.sys</itunes:name></itunes:owner><itunes:summary>Еженедельные импровизации на хай–тек темы</itunes:summary><itunes:category text="Technology"><itunes:category text="Tech News" /></itunes:category><itunes:category text="Technology"><itunes:category text="Gadgets" /></itunes:category><item>
+      <title>Радио-Т 762</title>
+      <description><![CDATA[<p><img src="https://radio-t.com/images/radio-t/rt762.jpg" alt=""></p>
+<p><em>Темы</em><ul>
+<li>Официальный кат №1 от Алексея - <em>00:14:35</em></li>
+<li>Официальный кат №2 от Алексея - <em>00:16:10</em></li>
+<li><a href="https://www.theguardian.com/commentisfree/2021/jul/05/amazon-worker-fired-app-dystopia">Злые роботы увольняют из Amazon</a> - <em>00:17:23</em>.</li>
+<li>Шутка от Алексея - <em>00:33:01</em></li>
+<li><a href="https://donjon.ledger.com/kaspersky-password-manager/">Пароли от Касперского не очень</a> - <em>00:33:16</em>.</li>
+<li>Шутка от Алексея - <em>00:44:43</em></li>
+<li><a href="https://copilot.github.com/">GitHub Copilot и проблема GPL</a> - <em>00:45:06</em>.</li>
+<li><a href="https://habr.com/ru/company/selectel/blog/565644/">Четырехдневная рабочая неделя</a> - <em>00:56:31</em>.</li>
+<li>Появились Умпутун и Ксюша - <em>01:04:54</em></li>
+<li><a href="https://techraptor.net/gaming/news/amazon-games-personal-game-policy">Невероятная политика Amazon про личные проекты</a> - <em>01:09:37</em>.</li>
+<li><a href="https://www.opennet.ru/opennews/art.shtml?num=55444">Созданы форки Audacity, избавленные от телеметрии</a> - <em>01:31:16</em>.</li>
+<li><a href="https://www.opennet.ru/opennews/art.shtml?num=55452">Создатель форка Audacity покинул проект</a> - <em>01:33:04</em>.</li>
+<li><a href="https://habr.com/ru/company/macloud/blog/566092/">Обзор самых неоднозначных проектов на Kickstarter</a> - <em>02:04:09</em>.</li>
+<li><a href="https://radio-t.com/p/2021/07/06/prep-762/">Темы слушателей</a> - <em>02:29:22</em>.</li>
+</ul></p>
+<p><em>Спонсор этого выпуска <a href="http://do.co/radiot-mongo">DigitalOcean</a></em></p>
+<p><a href="https://cdn.radio-t.com/rt_podcast762.mp3">аудио</a> • <a href="https://chat.radio-t.com/logs/radio-t-762.html">лог чата</a></p>
+<audio src="https://cdn.radio-t.com/rt_podcast762.mp3" preload="none"></audio>]]></description>
+      <link>https://radio-t.com/p/2021/07/10/podcast-762/</link>
+      <guid>https://radio-t.com/p/2021/07/10//podcast-762/</guid>
+      <pubDate>Sat, 10 Jul 2021 18:31:09 EST</pubDate>
+      <itunes:author>Umputun, Bobuk, Gray, Ksenks, Alek.sys</itunes:author>
+      <itunes:summary><![CDATA[<p><img src="https://radio-t.com/images/radio-t/rt762.jpg" alt=""></p>
+<ul>
+<li>Официальный кат №1 от Алексея - <em>00:14:35</em></li>
+<li>Официальный кат №2 от Алексея - <em>00:16:10</em></li>
+<li><a href="https://www.theguardian.com/commentisfree/2021/jul/05/amazon-worker-fired-app-dystopia">Злые роботы увольняют из Amazon</a> - <em>00:17:23</em>.</li>
+</ul>
+<p><em>Спонсор этого выпуска <a href="http://do.co/radiot-mongo">DigitalOcean</a></em></p>
+<p><a href="https://cdn.radio-t.com/rt_podcast762.mp3">аудио</a> • <a href="https://chat.radio-t.com/logs/radio-t-762.html">лог чата</a></p>
+<audio src="https://cdn.radio-t.com/rt_podcast762.mp3" preload="none"></audio>]]></itunes:summary>
+      <itunes:image href="https://radio-t.com/images/radio-t/rt762.jpg" />
+      <enclosure url="http://cdn.radio-t.com/rt_podcast762.mp3" type="audio/mp3" length="166608723" />
+    <author>podcast@radio-t.com (Umputun, Bobuk, Gray, Ksenks, Alek.sys)</author><media:content url="http://cdn.radio-t.com/rt_podcast762.mp3" fileSize="166608723" type="audio/mp3" /><itunes:explicit>no</itunes:explicit><itunes:subtitle>Подкаст выходного дня - импровизации на темы высоких технологий</itunes:subtitle><itunes:keywords>hitech,russian,radiot,tech,news,радио</itunes:keywords></item>
+  <media:credit role="author">Umputun, Bobuk, Gray, Ksenks, Alek.sys</media:credit><media:rating>nonadult</media:rating><media:description type="plain">Еженедельные импровизации на хай–тек темы</media:description></channel>
+</rss>
+`
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte(testFeed))
+		assert.NoError(t, err)
+	}))
+	r, err := Parse(ts.URL)
+	assert.NoError(t, err)
+	assert.Equal(t, "Еженедельные импровизации на хай–тек темы", r.Description)
+	assert.Equal(t, 1, len(r.ItemList))
+}
+
+func TestFeedParseBadBody(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, err := w.Write([]byte("bad"))
+		assert.NoError(t, err)
+	}))
+	r, err := Parse(ts.URL)
+	assert.Error(t, err)
+	assert.Empty(t, r)
 }
 
 func TestFeedParseHttpError(t *testing.T) {
@@ -73,7 +144,7 @@ func TestNormalizeIfLastBuildDateAndPubDateInvalidFormat(t *testing.T) {
 
 			got, err := rss.Normalize()
 
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, got.PubDate, "Mon, 02 Jan 2006 15:04:00 +0000")
 		})
 	}
@@ -120,7 +191,7 @@ func TestParseAtom(t *testing.T) {
 
 	got, err := parseAtom([]byte(atom1))
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, got.Title, "Example Feed")
 	assert.Equal(t, got.Description, "")
 
@@ -156,7 +227,7 @@ func TestParseFeedContentIfAtom1_0(t *testing.T) {
 
 	got, err := parseFeedContent([]byte(atom1))
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, got.Title, "Example Feed")
 }
 
@@ -191,7 +262,7 @@ func TestParseFeedContentIfRSSVersionEmptyContent(t *testing.T) {
 
 	got, err := parseFeedContent([]byte(rss))
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, got.ItemList[0].Content, template.HTML("Content"))
 	assert.Equal(t, got.ItemList[0].Description, template.HTML("Content"))
 }

--- a/app/main_test.go
+++ b/app/main_test.go
@@ -43,7 +43,7 @@ update: 600
 	assert.Nil(t, ioutil.WriteFile("/tmp/fm.yml", data, 0777), "failed write yml") // nolint
 
 	r, err := loadConfig("/tmp/fm.yml")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 3, len(r.Feeds), "3 sets")
 	assert.Equal(t, 2, len(r.Feeds["first"].Sources), "2 feeds in first")
 	assert.Equal(t, 1, len(r.Feeds["second"].Sources), "1 feed in second")

--- a/app/proc/store_test.go
+++ b/app/proc/store_test.go
@@ -20,7 +20,7 @@ func TestNewBoltDB(t *testing.T) {
 
 	boltDB, err := NewBoltDB(tmpfile.Name())
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, boltDB.DB.Path(), tmpfile.Name())
 }
 
@@ -60,7 +60,7 @@ func TestSave(t *testing.T) {
 	created, err := boltDB.Save("radio-t", item)
 
 	assert.True(t, created)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestSaveIfItemIsExists(t *testing.T) {
@@ -78,7 +78,7 @@ func TestSaveIfItemIsExists(t *testing.T) {
 	created, err := boltDB.Save("radio-t", item)
 
 	assert.False(t, created)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestLoadIfNotBucket(t *testing.T) {
@@ -102,7 +102,7 @@ func TestLoad(t *testing.T) {
 
 	items, err := boltDB.Load("radio-t", 5, false)
 
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(items))
 	assert.Equal(t, items[0].PubDate, pubDate)
 }
@@ -136,7 +136,7 @@ func TestLoadChackMax(t *testing.T) {
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			items, err := boltDB.Load("radio-t", tc.max, false)
 
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tc.count, len(items))
 		})
 	}
@@ -148,14 +148,14 @@ func TestBuckets(t *testing.T) {
 	boltDB, _ := NewBoltDB(tmpfile.Name())
 
 	got, err := boltDB.Buckets()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 0, len(got))
 
 	_, err = boltDB.Save("radio-t", feed.Item{PubDate: pubDate})
 	require.NoError(t, err)
 
 	got, err = boltDB.Buckets()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(got))
 }
 
@@ -195,7 +195,7 @@ func TestRemoveOld(t *testing.T) {
 
 			count, err := boltDB.removeOld("radio-t", tc.keep)
 
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, tc.countDelete, count)
 		})
 	}

--- a/app/proc/telegram_test.go
+++ b/app/proc/telegram_test.go
@@ -211,5 +211,5 @@ func TestDownloadAudio(t *testing.T) {
 	got, err := client.downloadAudio(ts.URL)
 
 	assert.NotNil(t, got)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }


### PR DESCRIPTION
I found that a single test doesn't work offline and fixed that, and also that it's impossible to get an error from RSS parse error: that PR fixes and tests it.