### PR TITLE
Fix feed processing loop premature exit on hitting known item

### DIFF
--- a/app/proc/processor.go
+++ b/app/proc/processor.go
@@ -145,10 +145,10 @@ func (p *Processor) feed(name, url, telegramChannel string, max int, filter Filt
 			log.Printf("[WARN] failed to save %s (%s) to %s, %v", item.GUID, item.PubDate, name, err)
 		}
 
-		// don't attempt to send anything if it was impossible to save the entry
+		// don't attempt to send anything if the entry was already saved
 		// or in case it was filtered out
 		if !created || item.Junk {
-			return
+			continue
 		}
 
 		if err := p.TelegramNotif.Send(telegramChannel, item); err != nil {


### PR DESCRIPTION
Before that change, the first found already created item causes the loop to exit. Was not a problem until I've added the filtered check condition to the same if cause after that filter was hitting it as well.