### PR TITLE
Add duration calculation error logging

### DIFF
--- a/app/duration/duration.go
+++ b/app/duration/duration.go
@@ -34,6 +34,7 @@ func (s *Service) Reader(r io.Reader) int {
 
 	for err == nil {
 		if err = d.Decode(&f, &skipped); err != nil && err != io.EOF {
+			log.Printf("[WARN] can't get duration for provided stream: %v", err)
 			return 0
 		}
 		duration += f.Duration().Seconds()


### PR DESCRIPTION
Part of resolution for #78: we would be able to see what's wrong if the errors would be logged.