### PR TITLE
Upload file to telegram from FS (instead of streaming it)

### DIFF
--- a/app/duration/duration.go
+++ b/app/duration/duration.go
@@ -20,11 +20,11 @@ func (s *Service) File(fname string) int {
 		return 0
 	}
 	defer fh.Close() // nolint
-	return s.Reader(fh)
+	return s.reader(fh)
 }
 
-// Reader scans MP3 from provided file and returns its duration in seconds, ignoring possible errors
-func (s *Service) Reader(r io.Reader) int {
+// reader scans MP3 from provided file and returns its duration in seconds, ignoring possible errors
+func (s *Service) reader(r io.Reader) int {
 	d := mp3.NewDecoder(r)
 
 	var f mp3.Frame

--- a/app/duration/duration_test.go
+++ b/app/duration/duration_test.go
@@ -26,5 +26,5 @@ func TestService_Reader(t *testing.T) {
 	reader := bytes.NewReader(smallMP3File)
 
 	svc := Service{}
-	assert.Zero(t, svc.Reader(reader))
+	assert.Zero(t, svc.reader(reader))
 }


### PR DESCRIPTION
Potential resolution for #78 as the problem might be caused by slow upload to Telegram, which causes the connection to the server we're reading the file from to drop. In the new setup, the application downloads the file first. Then uploads it to Telegram (and calculates the track duration) at the speed which is comfortable for Telegram, without making the uploading server wait.