### PR TITLE
Fix large file upload fallback

### DIFF
--- a/app/proc/telegram.go
+++ b/app/proc/telegram.go
@@ -63,7 +63,7 @@ func (client TelegramClient) Send(channelID string, item feed.Item) (err error) 
 	}
 
 	message, err := client.sendAudio(channelID, item)
-	if err != nil && strings.HasSuffix(err.Error(), "Request Entity Too Large") {
+	if err != nil && strings.Contains(err.Error(), "Request Entity Too Large") {
 		message, err = client.sendText(channelID, item)
 	}
 


### PR DESCRIPTION
Fallback is supposed to kick in the situation where the uploaded file is too big for Telegram and send a text message instead of audio in that case. It stopped working likely after library update and resulting error message change: this commit makes sure that the error is parsed correctly in the new conditions.

The fallback mechanism was originally added in #23.

The error message was supposedly changed in the library [v2.1](https://github.com/tucnak/telebot/releases/tag/v2.1.0) which was brought to the project on March 23 in e519a330f30ac4842a66dee829032b74021f1c12.