### PR TITLE
fix golangcilint errors on err variable reassignment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           GO111MODULE=off go get -u -v github.com/mattn/goveralls
 
       - name: run linters
-        run: $GITHUB_WORKSPACE/golangci-lint run
+        run: $GITHUB_WORKSPACE/golangci-lint run --out-format=github-actions
 
       - name: submit coverage
         run: $(go env GOPATH)/bin/goveralls -service="github" -coverprofile=$GITHUB_WORKSPACE/profile.cov

--- a/app/proc/telegram.go
+++ b/app/proc/telegram.go
@@ -99,10 +99,10 @@ func (client TelegramClient) sendAudio(channelID string, item feed.Item) (*tb.Me
 		return nil, err
 	}
 	defer os.Remove(tmpFile.Name())
-	if _, err = io.Copy(tmpFile, httpBody); err != nil {
+	if _, err := io.Copy(tmpFile, httpBody); err != nil {
 		return nil, err
 	}
-	if err = tmpFile.Close(); err != nil {
+	if err := tmpFile.Close(); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
[Error](https://github.com/umputun/feed-master/actions/runs/2206197437):

```
sloppyReassign: re-assignment to `err` can be replaced with `err := tmpFile.Close()` (gocritic)
```

Also, I noticed that error is not attributed to the right line, a change in ci.yaml fixes that.