### PR TITLE
Hardcode dockerhub username and ghcr.io repo for CI docker push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,11 +65,11 @@ jobs:
           ref="$(echo ${GITHUB_REF} | cut -d'/' -f3)"
           echo GITHUB_REF - $ref
           echo ${GITHUB_PACKAGE_TOKEN} | docker login ghcr.io -u ${USERNAME} --password-stdin
-          echo ${DOCKER_HUB_TOKEN} | docker login -u ${USERNAME} --password-stdin
+          echo ${DOCKER_HUB_TOKEN} | docker login -u umputun --password-stdin
           docker buildx build --push \
               --build-arg CI=github --build-arg GITHUB_SHA=${GITHUB_SHA} --build-arg GIT_BRANCH=${ref} \
               --platform linux/amd64,linux/arm/v7,linux/arm64 \
-              -t ghcr.io/${USERNAME}/feed-master:${ref} -t ${USERNAME}/feed-master:${ref} .
+              -t ghcr.io/umputun/feed-master:${ref} -t umputun/feed-master:${ref} .
 
       - name: deploy tagged (latest) to ghcr.io and dockerhub
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
@@ -83,9 +83,9 @@ jobs:
           ref="$(echo ${GITHUB_REF} | cut -d'/' -f3)"
           echo GITHUB_REF - $ref
           echo ${GITHUB_PACKAGE_TOKEN} | docker login ghcr.io -u ${USERNAME} --password-stdin
-          echo ${DOCKER_HUB_TOKEN} | docker login -u ${USERNAME} --password-stdin
+          echo ${DOCKER_HUB_TOKEN} | docker login -u umputun --password-stdin
           docker buildx build --push \
               --build-arg CI=github --build-arg GITHUB_SHA=${GITHUB_SHA} --build-arg GIT_BRANCH=${ref} \
               --platform linux/amd64,linux/arm/v7,linux/arm64 \
-              -t ghcr.io/${USERNAME}/feed-master:${ref} -t ghcr.io/${USERNAME}/feed-master:latest \
-              -t ${USERNAME}/feed-master:${ref} -t ${USERNAME}/feed-master:latest .
+              -t ghcr.io/umputun/feed-master:${ref} -t ghcr.io/umputun/feed-master:latest \
+              -t umputun/feed-master:${ref} -t umputun/feed-master:latest .


### PR DESCRIPTION
Currently, such a build most likely has access to secrets but fails due to the wrong username logging with DockerHub when rebase and merge is done by anyone but @umputun.