### PR TITLE
Invert filter

### DIFF
--- a/app/config/config.go
+++ b/app/config/config.go
@@ -61,18 +61,26 @@ type Feed struct {
 
 // Filter defines feed section for a feed filter~
 type Filter struct {
-	Title string `yaml:"title"`
+	Title  string `yaml:"title"`
+	Invert bool   `yaml:"invert"`
 }
 
 // Skip items with this regexp
 func (filter *Filter) Skip(item feed.Item) (bool, error) {
+	mayInvert := func(b bool) bool {
+		if filter.Invert {
+			return !b
+		}
+		return b
+	}
+
 	if filter.Title != "" {
 		matched, err := regexp.MatchString(filter.Title, item.Title)
 		if err != nil {
-			return matched, err
+			return mayInvert(matched), err
 		}
 		if matched {
-			return true, err
+			return mayInvert(true), err
 		}
 	}
 	return false, nil

--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -126,6 +126,24 @@ func TestFilter(t *testing.T) {
 			false,
 		},
 		{
+			Filter{Title: "(one|two|three)"},
+			rssfeed.Item{Title: "something blah one"},
+			nil,
+			true,
+		},
+		{
+			Filter{Title: "(one|two|three)", Invert: true},
+			rssfeed.Item{Title: "something blah one"},
+			nil,
+			false,
+		},
+		{
+			Filter{Title: "(one|two|three)", Invert: true},
+			rssfeed.Item{Title: "something blah two something"},
+			nil,
+			false,
+		},
+		{
 			Filter{},
 			rssfeed.Item{Title: "Title"},
 			nil,

--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -106,7 +106,7 @@ func TestSetDefault(t *testing.T) {
 	assert.Equal(t, "https://www.youtube.com/feeds/videos.xml?playlist_id=", c.YouTube.BasePlaylistURL)
 }
 
-func TestFilterAllCases(t *testing.T) {
+func TestFilter(t *testing.T) {
 	tbl := []struct {
 		filter Filter
 		inp    rssfeed.Item
@@ -120,7 +120,19 @@ func TestFilterAllCases(t *testing.T) {
 			true,
 		},
 		{
+			Filter{Title: "(Part \\d+)", Invert: true},
+			rssfeed.Item{Title: "Title (Part 1)"},
+			nil,
+			false,
+		},
+		{
 			Filter{},
+			rssfeed.Item{Title: "Title"},
+			nil,
+			false,
+		},
+		{
+			Filter{Invert: true},
 			rssfeed.Item{Title: "Title"},
 			nil,
 			false,


### PR DESCRIPTION
add a parameter `invert` to the filter. If set (to true) it will revers the logic, i.e. instead of "exclude matched" it will act as "include matched only". The change is back-compatible as the default value is false

Should address #103