### PR TITLE
Fix yt-dlp output filename template

### DIFF
--- a/app/config/config_test.go
+++ b/app/config/config_test.go
@@ -28,7 +28,7 @@ func TestLoad(t *testing.T) {
 	assert.Equal(t, []ytfdeed.FeedInfo{{Name: "name1", ID: "id1", Type: "playlist", Keep: 15},
 		{Name: "name2", ID: "id2", Type: "channel", Language: "ru-ru", Keep: 5}},
 		r.YouTube.Channels, "2 yt")
-	assert.Equal(t, "yt-dlp --extract-audio --audio-format=mp3 -f m4a/bestaudio \"https://www.youtube.com/watch?v={{.ID}}\" --no-progress -o {{.Filename}}.tmp", r.YouTube.DlTemplate)
+	assert.Equal(t, "yt-dlp --extract-audio --audio-format=mp3 -f m4a/bestaudio \"https://www.youtube.com/watch?v={{.ID}}\" --no-progress -o {{.Filename}}", r.YouTube.DlTemplate)
 	assert.Equal(t, "https://www.youtube.com/videos.xml?channel_id=", r.YouTube.BaseChanURL)
 	assert.Equal(t, "https://www.youtube.com/videos.xml?playlist_id=", r.YouTube.BasePlaylistURL)
 	assert.Equal(t, "./var/rss", r.YouTube.RSSLocation)

--- a/app/config/testdata/config.yml
+++ b/app/config/testdata/config.yml
@@ -42,7 +42,7 @@ system:
   update: 600s
 
 youtube:
-  dl_template: yt-dlp --extract-audio --audio-format=mp3 -f m4a/bestaudio "https://www.youtube.com/watch?v={{.ID}}" --no-progress -o {{.Filename}}.tmp
+  dl_template: yt-dlp --extract-audio --audio-format=mp3 -f m4a/bestaudio "https://www.youtube.com/watch?v={{.ID}}" --no-progress -o {{.Filename}}
   base_chan_url: "https://www.youtube.com/videos.xml?channel_id="
   base_playlist_url: "https://www.youtube.com/videos.xml?playlist_id="
   rss_location: ./var/rss

--- a/app/youtube/feed/downloader.go
+++ b/app/youtube/feed/downloader.go
@@ -38,7 +38,7 @@ func NewDownloader(tmpl string, logOutWriter, logErrWriter io.Writer, destinatio
 }
 
 // Get downloads a video from youtube and extracts audio.
-// yt-dlp --extract-audio --audio-format=mp3 --audio-quality=0 -f m4a/bestaudio "https://www.youtube.com/watch?v={{.ID}}" --no-progress -o {{.Filename}}.tmp
+// yt-dlp --extract-audio --audio-format=mp3 --audio-quality=0 -f m4a/bestaudio "https://www.youtube.com/watch?v={{.ID}}" --no-progress -o {{.Filename}}
 func (d *Downloader) Get(ctx context.Context, id, fname string) (file string, err error) {
 
 	if err := os.MkdirAll(d.destination, 0o750); err != nil {


### PR DESCRIPTION
After upgrading `yt-dlp`, the target file name is generated as `-o {{.Filename}}.tmp` + `.mp3`

```sh
$ pip3 freeze | grep yt-dlp
yt-dlp==2023.2.17

$ yt-dlp --extract-audio --audio-format=mp3 --audio-quality=0 -f m4a/bestaudio "https://www.youtube.com/watch?v=hhvNl2a04aM" --no-progress -o 4f92358fcd37f1e117962be5ab69f02cda651d4c.tmp
[youtube] Extracting URL: https://www.youtube.com/watch?v=hhvNl2a04aM
[youtube] hhvNl2a04aM: Downloading webpage
[youtube] hhvNl2a04aM: Downloading android player API JSON
[info] hhvNl2a04aM: Downloading 1 format(s): 140
[download] Destination: 4f92358fcd37f1e117962be5ab69f02cda651d4c.tmp
[download] Download completed
[FixupM4a] Correcting container of "4f92358fcd37f1e117962be5ab69f02cda651d4c.tmp"
[ExtractAudio] Destination: 4f92358fcd37f1e117962be5ab69f02cda651d4c.tmp.mp3
Deleting original file 4f92358fcd37f1e117962be5ab69f02cda651d4c.tmp (pass -k to keep)
```

But we expect to get `{{.Filename}}.mp3` that leads to skipping new entries

https://github.com/umputun/feed-master/blob/0bd1310d05f084e53ed739d0125c87f5608027be/app/youtube/feed/downloader.go#L70-L73

