### PR TITLE
Add dependabot updates for GitHub Actions and Go modules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      "GitHub Actions updates":
+        patterns:
+          - "*"
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      "Go modules updates":
+        dependency-type: "production"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ jobs:
           cat $GITHUB_WORKSPACE/profile.cov_tmp | grep -v "mocks" | grep -v "_mock" > $GITHUB_WORKSPACE/profile.cov
         working-directory: app
         env:
-          GO111MODULE: on
           TZ: "America/Chicago"
 
       - name: golangci-lint

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ ARG GIT_BRANCH
 ARG GITHUB_SHA
 ARG CI
 
-ENV GOFLAGS="-mod=vendor"
 ENV CGO_ENABLED=0
 
 ADD . /build
@@ -20,6 +19,9 @@ RUN \
 
 
 FROM umputun/baseimage:app-latest
+
+# enables automatic changelog generation by tools like Dependabot
+LABEL org.opencontainers.image.source="https://github.com/umputun/feed-master"
 
 COPY --from=build /build/feed-master /srv/feed-master
 COPY app/webapp /srv/webapp

--- a/Dockerfile.site
+++ b/Dockerfile.site
@@ -9,6 +9,8 @@ RUN mkdocs build
 
 
 FROM ghcr.io/umputun/reproxy
+# enables automatic changelog generation by tools like Dependabot
+LABEL org.opencontainers.image.source="https://github.com/umputun/feed-master"
 COPY --from=build /build/site /srv/site
 EXPOSE 8080
 USER app


### PR DESCRIPTION
There is no need for docker updates as the latest versions of containers are used.