### PR TITLE
Add yt-dlp auto-update functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ youtube: # youtube configuration, optional
       - {id: UCWAIvx2yYLK_xTYD4F2mUNw, name: "Живой Гвоздь", lang: "ru-ru"}
       - {id: UCuIE7-5QzeAR6EdZXwDRwuQ, name: "Дилетант", type: "channel", lang: "ru-ru", "keep": 10}
       - {id: PLZVQqcKxEn_6YaOniJmxATjODSVUbbMkd, name: "Точка", type: "playlist", lang: "ru-ru", filter: {include: "ТОЧКА", exclude: "STAR'цы Live"}} 
+  ytdlp_update: 
+    interval: 24h # update interval for yt-dlp. If not set, yt-dlp will not be updated 
+    cmd: "pip3 install --break-system-packages -U yt-dlp" # update yt-dlp command
 
 system: # system configuration
   update: 1m # update interval for checking source feeds

--- a/app/api/server.go
+++ b/app/api/server.go
@@ -59,12 +59,12 @@ type YoutubeSvc interface {
 
 // Store provides access to feed data
 type Store interface {
-	Load(fmFeed string, max int, skipJunk bool) ([]feed.Item, error)
+	Load(fmFeed string, maX int, skipJunk bool) ([]feed.Item, error)
 }
 
 // YoutubeStore provides access to YouTube channel data
 type YoutubeStore interface {
-	Load(channelID string, max int) ([]ytfeed.Entry, error)
+	Load(channelID string, maX int) ([]ytfeed.Entry, error)
 }
 
 // Run starts http server for API with all routes

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -37,6 +37,10 @@ type Conf struct {
 		RSSLocation     string             `yaml:"rss_location"`
 		SkipShorts      time.Duration      `yaml:"skip_shorts"`
 		DisableUpdates  bool               `yaml:"disable_updates"`
+		YtDlpUpdate     struct {
+			Interval time.Duration `yaml:"interval"`
+			Command  string        `yaml:"command"`
+		} `yaml:"ytdlp_update"`
 	} `yaml:"youtube"`
 }
 

--- a/app/main.go
+++ b/app/main.go
@@ -126,6 +126,14 @@ func main() {
 			DurationService: &duration.Service{},
 			SkipShorts:      conf.YouTube.SkipShorts,
 		}
+		if conf.YouTube.YtDlpUpdate.Interval > 0 {
+			log.Printf("[INFO] yt-dlp updater enabled, interval %s", conf.YouTube.YtDlpUpdate.Interval)
+			ytSvc.YtDlpUpdCommand = conf.YouTube.YtDlpUpdate.Command
+			ytSvc.YtDlpUpdDuration = conf.YouTube.YtDlpUpdate.Interval
+		} else {
+			log.Printf("[INFO] yt-dlp updater is disabled")
+		}
+
 		go func() {
 			if conf.YouTube.DisableUpdates {
 				log.Printf("[INFO] youtube updates are disabled")

--- a/app/proc/processor_test.go
+++ b/app/proc/processor_test.go
@@ -94,6 +94,10 @@ func TestProcessor_DoRemoveOldItems(t *testing.T) {
 				RSSLocation     string             `yaml:"rss_location"`
 				SkipShorts      time.Duration      `yaml:"skip_shorts"`
 				DisableUpdates  bool               `yaml:"disable_updates"`
+				YtDlpUpdate     struct {
+					Interval time.Duration `yaml:"interval"`
+					Command  string        `yaml:"command"`
+				} `yaml:"ytdlp_update"`
 			}{},
 		},
 		Store:         boltStore,
@@ -232,6 +236,10 @@ func TestProcessor_DoLoadMaxItems(t *testing.T) {
 				RSSLocation     string             `yaml:"rss_location"`
 				SkipShorts      time.Duration      `yaml:"skip_shorts"`
 				DisableUpdates  bool               `yaml:"disable_updates"`
+				YtDlpUpdate     struct {
+					Interval time.Duration `yaml:"interval"`
+					Command  string        `yaml:"command"`
+				} `yaml:"ytdlp_update"`
 			}{},
 		},
 		Store:         boltStore,
@@ -332,6 +340,10 @@ func TestProcessor_DoSkipItems(t *testing.T) {
 				RSSLocation     string             `yaml:"rss_location"`
 				SkipShorts      time.Duration      `yaml:"skip_shorts"`
 				DisableUpdates  bool               `yaml:"disable_updates"`
+				YtDlpUpdate     struct {
+					Interval time.Duration `yaml:"interval"`
+					Command  string        `yaml:"command"`
+				} `yaml:"ytdlp_update"`
 			}{},
 		},
 		Store:         boltStore,


### PR DESCRIPTION
This commit adds the ability to automatically update yt-dlp at specified intervals. It includes:

1. New configuration options for update interval and command
2. Implementation of the update mechanism in the YouTube service
3. Updates to the main application to enable the feature
4. Documentation of the new functionality in README.md

re: #141 
