### PR TITLE
Add force_on_startup option for yt-dlp updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ youtube: # youtube configuration, optional
   ytdlp_update: 
     interval: 24h # update interval for yt-dlp. If not set, yt-dlp will not be updated 
     command: "pip3 install --break-system-packages -U yt-dlp" # update yt-dlp command
+    force_on_startup: true # force yt-dlp update on startup, before the first channel processing. Default: false
 
 system: # system configuration
   update: 1m # update interval for checking source feeds

--- a/_example/etc/fm-yt.yml
+++ b/_example/etc/fm-yt.yml
@@ -24,6 +24,10 @@ youtube:
   - {id: UCWAIvx2yYLK_xTYD4F2mUNw, name: "Живой Гвоздь", lang: "ru-ru"}
   - {id: UCuIE7-5QzeAR6EdZXwDRwuQ, name: "Дилетант", type: "channel", lang: "ru-ru"}
   - {id: PLZVQqcKxEn_6YaOniJmxATjODSVUbbMkd, name: "Точка", type: "playlist", lang: "ru-ru", filter: {include: "ТОЧКА", exclude: "STAR'цы Live"}}
+  ytdlp_update:
+    interval: 24h
+    command: "pip3 install --break-system-packages -U yt-dlp"
+    force_on_startup: false
 
 system:
   update: 1m

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -39,8 +39,9 @@ type Conf struct {
 		SkipShorts      time.Duration      `yaml:"skip_shorts"`
 		DisableUpdates  bool               `yaml:"disable_updates"`
 		YtDlpUpdate     struct {
-			Interval time.Duration `yaml:"interval"`
-			Command  string        `yaml:"command"`
+			Interval       time.Duration `yaml:"interval"`
+			Command        string        `yaml:"command"`
+			ForceOnStartup bool          `yaml:"force_on_startup"`
 		} `yaml:"ytdlp_update"`
 	} `yaml:"youtube"`
 }

--- a/app/main.go
+++ b/app/main.go
@@ -131,6 +131,7 @@ func main() {
 			log.Printf("[INFO] yt-dlp updater enabled, interval %s", conf.YouTube.YtDlpUpdate.Interval)
 			ytSvc.YtDlpUpdCommand = conf.YouTube.YtDlpUpdate.Command
 			ytSvc.YtDlpUpdDuration = conf.YouTube.YtDlpUpdate.Interval
+			ytSvc.YtDlpUpdOnStart = conf.YouTube.YtDlpUpdate.ForceOnStartup
 		} else {
 			log.Printf("[INFO] yt-dlp updater is disabled")
 		}

--- a/app/main.go
+++ b/app/main.go
@@ -127,13 +127,13 @@ func main() {
 			DurationService: &duration.Service{},
 			SkipShorts:      conf.YouTube.SkipShorts,
 		}
+		ytSvc.YtDlpUpdCommand = conf.YouTube.YtDlpUpdate.Command
+		ytSvc.YtDlpUpdOnStart = conf.YouTube.YtDlpUpdate.ForceOnStartup
 		if conf.YouTube.YtDlpUpdate.Interval > 0 {
 			log.Printf("[INFO] yt-dlp updater enabled, interval %s", conf.YouTube.YtDlpUpdate.Interval)
-			ytSvc.YtDlpUpdCommand = conf.YouTube.YtDlpUpdate.Command
 			ytSvc.YtDlpUpdDuration = conf.YouTube.YtDlpUpdate.Interval
-			ytSvc.YtDlpUpdOnStart = conf.YouTube.YtDlpUpdate.ForceOnStartup
 		} else {
-			log.Printf("[INFO] yt-dlp updater is disabled")
+			log.Printf("[INFO] yt-dlp periodic updater is disabled")
 		}
 
 		go func() {

--- a/app/proc/processor_test.go
+++ b/app/proc/processor_test.go
@@ -95,8 +95,9 @@ func TestProcessor_DoRemoveOldItems(t *testing.T) {
 				SkipShorts      time.Duration      `yaml:"skip_shorts"`
 				DisableUpdates  bool               `yaml:"disable_updates"`
 				YtDlpUpdate     struct {
-					Interval time.Duration `yaml:"interval"`
-					Command  string        `yaml:"command"`
+					Interval       time.Duration `yaml:"interval"`
+					Command        string        `yaml:"command"`
+					ForceOnStartup bool          `yaml:"force_on_startup"`
 				} `yaml:"ytdlp_update"`
 			}{},
 		},
@@ -233,8 +234,9 @@ func TestProcessor_DoLoadMaxItems(t *testing.T) {
 				SkipShorts      time.Duration      `yaml:"skip_shorts"`
 				DisableUpdates  bool               `yaml:"disable_updates"`
 				YtDlpUpdate     struct {
-					Interval time.Duration `yaml:"interval"`
-					Command  string        `yaml:"command"`
+					Interval       time.Duration `yaml:"interval"`
+					Command        string        `yaml:"command"`
+					ForceOnStartup bool          `yaml:"force_on_startup"`
 				} `yaml:"ytdlp_update"`
 			}{},
 		},
@@ -336,8 +338,9 @@ func TestProcessor_DoSkipItems(t *testing.T) {
 				SkipShorts      time.Duration      `yaml:"skip_shorts"`
 				DisableUpdates  bool               `yaml:"disable_updates"`
 				YtDlpUpdate     struct {
-					Interval time.Duration `yaml:"interval"`
-					Command  string        `yaml:"command"`
+					Interval       time.Duration `yaml:"interval"`
+					Command        string        `yaml:"command"`
+					ForceOnStartup bool          `yaml:"force_on_startup"`
 				} `yaml:"ytdlp_update"`
 			}{},
 		},

--- a/app/proc/testdata/rss1.xml
+++ b/app/proc/testdata/rss1.xml
@@ -62,7 +62,7 @@
 <audio src="https://cdn.radio-t.com/rt_podcast798.mp3" preload="none"></audio>]]></description>
       <link>https://radio-t.com/p/2022/03/19/podcast-798/</link>
       <guid>https://radio-t.com/p/2022/03/19//podcast-798/</guid>
-      <pubDate>Sat, 19 Mar 2025 19:35:46 EST</pubDate>
+      <pubDate>Sat, 19 Mar 2026 19:35:46 EST</pubDate>
       <itunes:author>Umputun, Bobuk, Gray, Ksenks, Alek.sys</itunes:author>
       <itunes:summary><![CDATA[<p><img src="https://radio-t.com/images/radio-t/rt798.jpg" alt=""></p>
 <ul>
@@ -107,7 +107,7 @@
 <audio src="https://cdn.radio-t.com/rt_podcast797.mp3" preload="none"></audio>]]></description>
       <link>https://radio-t.com/p/2022/03/12/podcast-797/</link>
       <guid>https://radio-t.com/p/2022/03/12//podcast-797/</guid>
-      <pubDate>Sat, 12 Mar 2025 16:31:49 EST</pubDate>
+      <pubDate>Sat, 12 Mar 2026 16:31:49 EST</pubDate>
       <itunes:author>Umputun, Bobuk, Gray, Ksenks, Alek.sys</itunes:author>
       <itunes:summary><![CDATA[<p><img src="https://radio-t.com/images/radio-t/rt797.jpg" alt=""></p>
 <ul>
@@ -153,7 +153,7 @@
 <audio src="https://cdn.radio-t.com/rt_podcast796.mp3" preload="none"></audio>]]></description>
       <link>https://radio-t.com/p/2022/03/05/podcast-796/</link>
       <guid>https://radio-t.com/p/2022/03/05//podcast-796/</guid>
-      <pubDate>Sat, 05 Mar 2025 18:06:03 EST</pubDate>
+      <pubDate>Sat, 05 Mar 2026 18:06:03 EST</pubDate>
       <itunes:author>Umputun, Bobuk, Gray, Ksenks, Alek.sys</itunes:author>
       <itunes:summary><![CDATA[<p><img src="https://radio-t.com/images/radio-t/rt796.jpg" alt=""></p>
 <ul>

--- a/app/proc/testdata/rss2.xml
+++ b/app/proc/testdata/rss2.xml
@@ -59,7 +59,7 @@
 <audio src="https://cdn.radio-t.com/rt_podcast801.mp3" preload="none"></audio>]]></description>
       <link>https://radio-t.com/p/2022/04/09/podcast-801/</link>
       <guid>https://radio-t.com/p/2022/04/09//podcast-801/</guid>
-      <pubDate>Sat, 09 Apr 2025 17:51:21 EST</pubDate>
+      <pubDate>Sat, 09 Apr 2026 17:51:21 EST</pubDate>
       <itunes:author>Umputun, Bobuk, Gray, Ksenks, Alek.sys</itunes:author>
       <itunes:summary><![CDATA[<p><img src="https://radio-t.com/images/radio-t/rt801.jpg" alt=""></p>
 <ul>
@@ -103,7 +103,7 @@
 <audio src="https://cdn.radio-t.com/rt_podcast800.mp3" preload="none"></audio>]]></description>
       <link>https://radio-t.com/p/2022/04/02/podcast-800/</link>
       <guid>https://radio-t.com/p/2022/04/02//podcast-800/</guid>
-      <pubDate>Sat, 02 Apr 2025 19:05:55 EST</pubDate>
+      <pubDate>Sat, 02 Apr 2026 19:05:55 EST</pubDate>
       <itunes:author>Umputun, Bobuk, Gray, Ksenks, Alek.sys</itunes:author>
       <itunes:summary><![CDATA[<p><img src="https://radio-t.com/images/radio-t/rt800.jpg" alt=""></p>
 <ul>
@@ -152,7 +152,7 @@
 <audio src="https://cdn.radio-t.com/rt_podcast799.mp3" preload="none"></audio>]]></description>
       <link>https://radio-t.com/p/2022/03/26/podcast-799/</link>
       <guid>https://radio-t.com/p/2022/03/26//podcast-799/</guid>
-      <pubDate>Sat, 26 Mar 2025 19:07:00 EST</pubDate>
+      <pubDate>Sat, 26 Mar 2026 19:07:00 EST</pubDate>
       <itunes:author>Umputun, Bobuk, Gray, Ksenks, Alek.sys</itunes:author>
       <itunes:summary><![CDATA[<p><img src="https://radio-t.com/images/radio-t/rt799.jpg" alt=""></p>
 <ul>
@@ -200,7 +200,7 @@
 <audio src="https://cdn.radio-t.com/rt_podcast798.mp3" preload="none"></audio>]]></description>
       <link>https://radio-t.com/p/2022/03/19/podcast-798/</link>
       <guid>https://radio-t.com/p/2022/03/19//podcast-798/</guid>
-      <pubDate>Sat, 19 Mar 2025 19:35:46 EST</pubDate>
+      <pubDate>Sat, 19 Mar 2026 19:35:46 EST</pubDate>
       <itunes:author>Umputun, Bobuk, Gray, Ksenks, Alek.sys</itunes:author>
       <itunes:summary><![CDATA[<p><img src="https://radio-t.com/images/radio-t/rt798.jpg" alt=""></p>
 <ul>
@@ -245,7 +245,7 @@
 <audio src="https://cdn.radio-t.com/rt_podcast797.mp3" preload="none"></audio>]]></description>
       <link>https://radio-t.com/p/2022/03/12/podcast-797/</link>
       <guid>https://radio-t.com/p/2022/03/12//podcast-797/</guid>
-      <pubDate>Sat, 12 Mar 2025 16:31:49 EST</pubDate>
+      <pubDate>Sat, 12 Mar 2026 16:31:49 EST</pubDate>
       <itunes:author>Umputun, Bobuk, Gray, Ksenks, Alek.sys</itunes:author>
       <itunes:summary><![CDATA[<p><img src="https://radio-t.com/images/radio-t/rt797.jpg" alt=""></p>
 <ul>
@@ -291,7 +291,7 @@
 <audio src="https://cdn.radio-t.com/rt_podcast796.mp3" preload="none"></audio>]]></description>
       <link>https://radio-t.com/p/2022/03/05/podcast-796/</link>
       <guid>https://radio-t.com/p/2022/03/05//podcast-796/</guid>
-      <pubDate>Sat, 05 Mar 2025 18:06:03 EST</pubDate>
+      <pubDate>Sat, 05 Mar 2026 18:06:03 EST</pubDate>
       <itunes:author>Umputun, Bobuk, Gray, Ksenks, Alek.sys</itunes:author>
       <itunes:summary><![CDATA[<p><img src="https://radio-t.com/images/radio-t/rt796.jpg" alt=""></p>
 <ul>
@@ -339,7 +339,7 @@
 <audio src="https://cdn.radio-t.com/rt_podcast795.mp3" preload="none"></audio>]]></description>
       <link>https://radio-t.com/p/2022/02/26/podcast-795/</link>
       <guid>https://radio-t.com/p/2022/02/26//podcast-795/</guid>
-      <pubDate>Sat, 26 Feb 2025 16:53:31 EST</pubDate>
+      <pubDate>Sat, 26 Feb 2026 16:53:31 EST</pubDate>
       <itunes:author>Umputun, Bobuk, Gray, Ksenks, Alek.sys</itunes:author>
       <itunes:summary><![CDATA[<p><img src="https://radio-t.com/images/radio-t/rt795.jpg" alt=""></p>
 <ul>

--- a/app/youtube/service.go
+++ b/app/youtube/service.go
@@ -45,6 +45,7 @@ type Service struct {
 
 	YtDlpUpdDuration time.Duration
 	YtDlpUpdCommand  string
+	YtDlpUpdOnStart  bool
 }
 
 // FeedInfo contains channel or feed ID, readable name and other per-feed info
@@ -94,6 +95,9 @@ type DurationService interface {
 // Do is a blocking function that downloads audio from youtube channels and updates metadata
 func (s *Service) Do(ctx context.Context) error {
 	log.Printf("[INFO] starting youtube service")
+	if s.YtDlpUpdOnStart && s.YtDlpUpdCommand != "" {
+		s.execYtdlpUpdate(ctx, s.YtDlpUpdCommand)
+	}
 	lastYtDlpUpdate := time.Now()
 	if s.SkipShorts > 0 {
 		log.Printf("[DEBUG] skip youtube episodes shorter than %v", s.SkipShorts)

--- a/app/youtube/service_test.go
+++ b/app/youtube/service_test.go
@@ -18,6 +18,66 @@ import (
 	"github.com/umputun/feed-master/app/youtube/mocks"
 )
 
+func TestService_DoYtDlpUpdateOnStartup(t *testing.T) {
+	tempDir := t.TempDir()
+	markerFile := filepath.Join(tempDir, "ytdlp-updated")
+
+	chans := &mocks.ChannelServiceMock{
+		GetFunc: func(_ context.Context, chanID string, _ ytfeed.Type) ([]ytfeed.Entry, error) {
+			return []ytfeed.Entry{}, nil
+		},
+	}
+
+	tmpfile := filepath.Join(tempDir, "test.db")
+	db, err := bolt.Open(tmpfile, 0o600, &bolt.Options{Timeout: 1 * time.Second})
+	require.NoError(t, err)
+	boltStore := &store.BoltDB{DB: db}
+
+	t.Run("runs update on startup when enabled", func(t *testing.T) {
+		os.Remove(markerFile)
+		svc := Service{
+			Feeds:           []FeedInfo{{ID: "ch1", Name: "n1", Type: ytfeed.FTChannel}},
+			Downloader:      &mocks.DownloaderServiceMock{},
+			ChannelService:  chans,
+			Store:           boltStore,
+			CheckDuration:   time.Millisecond * 500,
+			KeepPerChannel:  10,
+			RSSFileStore:    RSSFileStore{Enabled: false},
+			DurationService: &mocks.DurationServiceMock{FileFunc: func(string) int { return 0 }},
+			YtDlpUpdOnStart: true,
+			YtDlpUpdCommand: "touch " + markerFile,
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*600)
+		defer cancel()
+		_ = svc.Do(ctx)
+
+		assert.FileExists(t, markerFile, "yt-dlp update command should run on startup")
+	})
+
+	t.Run("skips update on startup when disabled", func(t *testing.T) {
+		os.Remove(markerFile)
+		svc := Service{
+			Feeds:           []FeedInfo{{ID: "ch1", Name: "n1", Type: ytfeed.FTChannel}},
+			Downloader:      &mocks.DownloaderServiceMock{},
+			ChannelService:  chans,
+			Store:           boltStore,
+			CheckDuration:   time.Millisecond * 500,
+			KeepPerChannel:  10,
+			RSSFileStore:    RSSFileStore{Enabled: false},
+			DurationService: &mocks.DurationServiceMock{FileFunc: func(string) int { return 0 }},
+			YtDlpUpdOnStart: false,
+			YtDlpUpdCommand: "touch " + markerFile,
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Millisecond*600)
+		defer cancel()
+		_ = svc.Do(ctx)
+
+		assert.NoFileExists(t, markerFile, "yt-dlp update command should not run when force_on_startup is false")
+	})
+}
+
 func TestService_Do(t *testing.T) {
 	tempDir := t.TempDir()
 	shortVideo := filepath.Join(tempDir, "122b672d10e77708b51c041f852615dc0eedf354.mp3")


### PR DESCRIPTION
## Summary

- Adds `force_on_startup` boolean option to the `ytdlp_update` configuration section
- When enabled, runs the yt-dlp update command once at service startup, before the first channel processing attempt
- Disabled by default for backward compatibility

## Motivation

When a fresh container is started (e.g., `docker-compose up` with a new or rebuilt image), the yt-dlp package bundled in the image may already be outdated — YouTube frequently changes its internal API, and even a recently built image can ship a stale version. In this case, all YouTube downloads will fail from the very first attempt.

The current yt-dlp update logic only runs periodically (e.g., every 24h) and resets the timer on startup (`lastYtDlpUpdate = time.Now()`), so the first scheduled update won't happen until the full interval passes. This means the service can be unable to download anything for up to 24 hours after starting a fresh container.

With `force_on_startup: true`, feed-master ensures yt-dlp is updated before attempting any downloads, eliminating this startup gap.

## Configuration example

```yaml
youtube:
  ytdlp_update:
    interval: 24h
    command: "pip3 install --break-system-packages -U yt-dlp"
    force_on_startup: true
```

## Changes

- `app/config/config.go`: Added `ForceOnStartup bool` field to `YtDlpUpdate` struct
- `app/youtube/service.go`: Added `YtDlpUpdOnStart` field to `Service` struct; runs `execYtdlpUpdate()` at the start of `Do()` when enabled
- `app/main.go`: Wires the new config field to the service
- `app/proc/processor_test.go`: Updated inline config structs to include the new field
- `README.md`: Updated config documentation with the new option
- `_example/etc/fm-yt.yml`: Added `ytdlp_update` section with all options

## Test plan

- [x] All existing tests pass (`go test -race ./app/...`)
- [x] Linter passes with no new issues (`golangci-lint run ./app/...`)
- [x] New option defaults to `false`, preserving backward compatibility
- [x] When `force_on_startup: true` and command is set, update runs before first `procChannels()`
- [x] When `force_on_startup: false` or command is empty, startup behavior is unchanged