### PR TITLE
add event == 'push' guard to docker workflows

### DIFF
--- a/.github/workflows/docker-site.yml
+++ b/.github/workflows/docker-site.yml
@@ -9,6 +9,7 @@ jobs:
   build:
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
       (github.event.workflow_run.head_branch == 'master' ||
        startsWith(github.event.workflow_run.head_branch, 'v'))
     strategy:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,6 +9,7 @@ jobs:
   build:
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
       (github.event.workflow_run.head_branch == 'master' ||
        startsWith(github.event.workflow_run.head_branch, 'v'))
     strategy:


### PR DESCRIPTION
## Summary
- add `github.event.workflow_run.event == 'push'` guard to both `docker.yml` and `docker-site.yml`
- prevents workflow_run-triggered Docker builds from firing when upstream CI completes for a pull_request event

Context: https://www.stepsecurity.io/blog/hackerbot-claw-github-actions-exploitation