### PR TITLE
Remove unused exported symbols and document all public API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,15 +115,28 @@ In both configuration modes, user can specify a list of telegram and twitter acc
 
 _See [requests.http](https://github.com/umputun/feed-master/blob/master/requests.http)_
 
+All `GET` endpoints are public and require no authentication. The two endpoints which modify state are protected by Basic authentication with the user `admin` and the password set by `--admin-passwd`; if that option is not set, a random password is generated on startup and the protected endpoints become unreachable.
+
 ### public endpoints
 
-- `GET /rss/{name}` - returns feed-set for given feed name
-- `GET /list` - returns list of feed-sets (json)
-- `GET /image/{name}` - returns image for given feed name
-- `GET /feed/{name}/sources` - returns list of sources for given feed name
-- `GET /yt/rss/{channel}` - return RSS feed for given youtube channel
+- `GET /rss/{name}` - returns the generated RSS feed for the given feed name
+- `GET /list` - returns the list of feed-sets (json)
+- `GET /config` - returns the currently loaded configuration (json)
+- `GET /image/{name}` and `GET /images/{name}` - returns the image for the given feed name
+- `GET /feeds` - renders the page listing all feeds
+- `GET /feed/{name}` - renders the page with items of the given feed
+- `GET /feed/{name}/sources` - renders the page listing sources of the given feed
+- `GET /feed/{name}/source/{source}` - renders the page with items of the given feed coming from a single source
+- `GET /yt/rss/{channel}` - returns the RSS feed for the given youtube channel or playlist
+- `GET /yt/channels` - renders the page listing all youtube channels and playlists
+- `GET /static/{file...}` - serves the static assets of the web UI
+- `GET /ping` - health check, responds with `pong`
+
+The downloaded youtube audio files are served from the path of `youtube.base_url`, which defaults to `<system.base_url>/yt/media`.
 
 ### admin endpoints
+
+Both require Basic authentication, see above.
 
 - `POST /yt/rss/generate` - regenerate RSS feed for all youtube channels
 - `DELETE /yt/entry/{channel}/{video}` - delete youtube entry, remove associated audio file, and remove from combined feeds

--- a/app/config/config.go
+++ b/app/config/config.go
@@ -92,12 +92,6 @@ func (filter *Filter) Skip(item feed.Item) (bool, error) {
 	return false, nil
 }
 
-// YTChannel defines youtube channel config
-type YTChannel struct {
-	ID   string
-	Name string
-}
-
 // Load config from file
 func Load(fname string) (res *Conf, err error) {
 	res = &Conf{}

--- a/app/youtube/store/store.go
+++ b/app/youtube/store/store.go
@@ -323,25 +323,6 @@ func (s *BoltDB) CountProcessed() (count int) {
 	return count
 }
 
-// ListProcessed returns processed entries stored in processedBkt
-func (s *BoltDB) ListProcessed() (res []string, err error) {
-	err = s.View(func(tx *bolt.Tx) error {
-		bucket := tx.Bucket(processedBkt)
-		if bucket == nil {
-			return nil
-		}
-		c := bucket.Cursor()
-		for k, v := c.Last(); k != nil; k, v = c.Prev() {
-			res = append(res, string(k)+" / "+string(v))
-		}
-		return nil
-	})
-	if err != nil {
-		return res, fmt.Errorf("view store: %w", err)
-	}
-	return res, nil
-}
-
 func (s *BoltDB) key(entry feed.Entry) ([]byte, error) {
 	h := sha1.New()
 	if _, err := h.Write([]byte(entry.VideoID)); err != nil {

--- a/app/youtube/store/store_test.go
+++ b/app/youtube/store/store_test.go
@@ -234,13 +234,6 @@ func TestBoltDB_SetProcessed(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, found)
 
-	lst, err := s.ListProcessed()
-	require.NoError(t, err)
-	assert.Len(t, lst, 3)
-	assert.Equal(t, "dbff863dbc922f727afb93e949704da777739489 / 2022-03-21T16:45:22Z", lst[0])
-	assert.Equal(t, "ae9a2ed8bbf505091e35b9d54ccb9dc58e35c205 / 2022-03-21T18:45:22Z", lst[1])
-	assert.Equal(t, "a8fd9875c236fb27e26183b6df87f0cecb7a683f / 2022-03-21T17:45:22Z", lst[2])
-
 	err = s.ResetProcessed(feed.Entry{ChannelID: "chan1", VideoID: "vid2"})
 	require.NoError(t, err)
 	found, _, err = s.CheckProcessed(feed.Entry{ChannelID: "chan1", VideoID: "vid2"})


### PR DESCRIPTION
Three cleanups from a review pass over the current master. No behaviour change: two provably unreferenced exported symbols are removed and the README API section is brought in line with the routes actually registered.

### Unused `config.YTChannel`

`Conf.YouTube.Channels` is declared as `[]youtube.FeedInfo` (`app/config/config.go:33`), and that type, defined at `app/youtube/service.go:52`, is what `app/main.go:116` passes into the service. A repository-wide search finds no reference to `config.YTChannel` at all, so it is removed.

### Unused `BoltDB.ListProcessed`

`BoltDB.ListProcessed` had a single caller, the store's own test. It does not appear in the `StoreService` interface consumed by the youtube service, nor in `YoutubeStore` consumed by the API, so no runtime path reached it. Removed along with its assertions in `TestBoltDB_SetProcessed`; the rest of that test, which covers `SetProcessed`, `CountProcessed`, `CheckProcessed` and `ResetProcessed`, is untouched.

Both symbols are exported, but the module is an application rather than a library, so there is nothing downstream compiling against them.

### API documentation

The public endpoint list covered five of the twelve registered GET routes and said nothing about which endpoints require authentication. `/feeds`, `/config`, `/feed/{name}`, `/feed/{name}/source/{source}`, `/yt/channels`, `/static/{file...}` and `/ping` were all undocumented, and `/config` in particular could be mistaken for a protected endpoint since it renders the whole loaded configuration. The list now matches `router()` in `app/api/server.go` and states explicitly that every GET route is public, while `POST /yt/rss/generate` and `DELETE /yt/entry/{channel}/{video}` require Basic authentication with the password from `--admin-passwd`.

The note about audio files now says they are served from the path of `youtube.base_url`, which `setDefaults` fills in as `<system.base_url>/yt/media` when it is left empty, rather than implying the route is conditional.



The `build` check on this branch fails at the `golangci-lint` step on two pre-existing `gosec` findings in `app/youtube/service_test.go` which have kept master red since a4226be. They are fixed in #172; the test step here passes.
