### PR TITLE
Fix the gosec failure keeping master red, isolate test temp files

### DIFF
--- a/app/api/server_test.go
+++ b/app/api/server_test.go
@@ -27,9 +27,12 @@ func TestServer_Run(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	port := rand.Intn(10000) + 4000 //nolint:gosec // math/rand is fine for test port selection
+	done := make(chan struct{})
 	go func() {
+		defer close(done)
 		time.Sleep(time.Millisecond * 100)
-		resp, err := http.Get(fmt.Sprintf("http://localhost:%d/ping", port))
+		client := &http.Client{Timeout: 5 * time.Second}
+		resp, err := client.Get(fmt.Sprintf("http://localhost:%d/ping", port))
 		if !assert.NoError(t, err) {
 			return
 		}
@@ -40,6 +43,7 @@ func TestServer_Run(t *testing.T) {
 		assert.Equal(t, "feed-master", resp.Header.Get("App-Name"))
 	}()
 	s.Run(ctx, port)
+	<-done
 }
 
 func TestServer_getFeedCtrl(t *testing.T) {

--- a/app/api/server_test.go
+++ b/app/api/server_test.go
@@ -30,7 +30,9 @@ func TestServer_Run(t *testing.T) {
 	go func() {
 		time.Sleep(time.Millisecond * 100)
 		resp, err := http.Get(fmt.Sprintf("http://localhost:%d/ping", port))
-		assert.NoError(t, err)
+		if !assert.NoError(t, err) {
+			return
+		}
 		defer resp.Body.Close()
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 		t.Logf("%+v", resp.Header)

--- a/app/proc/processor_test.go
+++ b/app/proc/processor_test.go
@@ -31,8 +31,7 @@ func TestProcessor_DoRemoveOldItems(t *testing.T) {
 		return nil
 	}}
 
-	tmpfile := filepath.Join(os.TempDir(), "test.db")
-	defer os.Remove(tmpfile)
+	tmpfile := filepath.Join(t.TempDir(), "test.db")
 
 	db, err := bolt.Open(tmpfile, 0o600, &bolt.Options{Timeout: 2 * time.Second})
 	require.NoError(t, err)
@@ -170,8 +169,7 @@ func TestProcessor_DoLoadMaxItems(t *testing.T) {
 		return nil
 	}}
 
-	tmpfile := filepath.Join(os.TempDir(), "test.db")
-	defer os.Remove(tmpfile)
+	tmpfile := filepath.Join(t.TempDir(), "test.db")
 
 	db, err := bolt.Open(tmpfile, 0o600, &bolt.Options{Timeout: 1 * time.Second})
 	require.NoError(t, err)
@@ -272,8 +270,7 @@ func TestProcessor_DoSkipItems(t *testing.T) {
 		return nil
 	}}
 
-	tmpfile := filepath.Join(os.TempDir(), "test.db")
-	defer os.Remove(tmpfile)
+	tmpfile := filepath.Join(t.TempDir(), "test.db")
 
 	db, err := bolt.Open(tmpfile, 0o600, &bolt.Options{Timeout: 1 * time.Second})
 	require.NoError(t, err)

--- a/app/proc/processor_test.go
+++ b/app/proc/processor_test.go
@@ -35,6 +35,7 @@ func TestProcessor_DoRemoveOldItems(t *testing.T) {
 
 	db, err := bolt.Open(tmpfile, 0o600, &bolt.Options{Timeout: 2 * time.Second})
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
 	boltStore := &BoltDB{DB: db}
 
 	testFeed, err := os.ReadFile("./testdata/rss1.xml")
@@ -173,6 +174,7 @@ func TestProcessor_DoLoadMaxItems(t *testing.T) {
 
 	db, err := bolt.Open(tmpfile, 0o600, &bolt.Options{Timeout: 1 * time.Second})
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
 	boltStore := &BoltDB{DB: db}
 
 	testFeed, err := os.ReadFile("./testdata/rss2.xml")
@@ -274,6 +276,7 @@ func TestProcessor_DoSkipItems(t *testing.T) {
 
 	db, err := bolt.Open(tmpfile, 0o600, &bolt.Options{Timeout: 1 * time.Second})
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
 	boltStore := &BoltDB{DB: db}
 
 	testFeed, err := os.ReadFile("./testdata/rss1.xml")

--- a/app/youtube/service_test.go
+++ b/app/youtube/service_test.go
@@ -208,8 +208,7 @@ func TestService_DoIsAllowedFilter(t *testing.T) {
 		},
 	}
 
-	tmpfile := filepath.Join(os.TempDir(), "test.db")
-	defer os.Remove(tmpfile)
+	tmpfile := filepath.Join(t.TempDir(), "test.db")
 
 	db, err := bolt.Open(tmpfile, 0o600, &bolt.Options{Timeout: 5 * time.Second})
 	require.NoError(t, err)

--- a/app/youtube/service_test.go
+++ b/app/youtube/service_test.go
@@ -34,7 +34,7 @@ func TestService_DoYtDlpUpdateOnStartup(t *testing.T) {
 	boltStore := &store.BoltDB{DB: db}
 
 	t.Run("runs update on startup when enabled", func(t *testing.T) {
-		os.Remove(markerFile)
+		_ = os.Remove(markerFile)
 		svc := Service{
 			Feeds:           []FeedInfo{{ID: "ch1", Name: "n1", Type: ytfeed.FTChannel}},
 			Downloader:      &mocks.DownloaderServiceMock{},
@@ -56,7 +56,7 @@ func TestService_DoYtDlpUpdateOnStartup(t *testing.T) {
 	})
 
 	t.Run("skips update on startup when disabled", func(t *testing.T) {
-		os.Remove(markerFile)
+		_ = os.Remove(markerFile)
 		svc := Service{
 			Feeds:           []FeedInfo{{ID: "ch1", Name: "n1", Type: ytfeed.FTChannel}},
 			Downloader:      &mocks.DownloaderServiceMock{},

--- a/app/youtube/service_test.go
+++ b/app/youtube/service_test.go
@@ -31,6 +31,7 @@ func TestService_DoYtDlpUpdateOnStartup(t *testing.T) {
 	tmpfile := filepath.Join(tempDir, "test.db")
 	db, err := bolt.Open(tmpfile, 0o600, &bolt.Options{Timeout: 1 * time.Second})
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
 	boltStore := &store.BoltDB{DB: db}
 
 	t.Run("runs update on startup when enabled", func(t *testing.T) {
@@ -114,6 +115,7 @@ func TestService_Do(t *testing.T) {
 
 	db, err := bolt.Open(tmpfile, 0o600, &bolt.Options{Timeout: 1 * time.Second})
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
 	boltStore := &store.BoltDB{DB: db}
 	svc := Service{
 		Feeds: []FeedInfo{
@@ -187,6 +189,8 @@ func TestService_Do(t *testing.T) {
 }
 
 func TestService_DoIsAllowedFilter(t *testing.T) {
+	tempDir := t.TempDir()
+
 	chans := &mocks.ChannelServiceMock{
 		GetFunc: func(_ context.Context, chanID string, _ ytfeed.Type) ([]ytfeed.Entry, error) {
 			return []ytfeed.Entry{
@@ -198,7 +202,7 @@ func TestService_DoIsAllowedFilter(t *testing.T) {
 	}
 	downloader := &mocks.DownloaderServiceMock{
 		GetFunc: func(_ context.Context, _ string, fname string) (string, error) {
-			return "/tmp/" + fname + ".mp3", nil
+			return filepath.Join(tempDir, fname+".mp3"), nil
 		},
 	}
 
@@ -208,10 +212,11 @@ func TestService_DoIsAllowedFilter(t *testing.T) {
 		},
 	}
 
-	tmpfile := filepath.Join(t.TempDir(), "test.db")
+	tmpfile := filepath.Join(tempDir, "test.db")
 
 	db, err := bolt.Open(tmpfile, 0o600, &bolt.Options{Timeout: 5 * time.Second})
 	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
 	boltStore := &store.BoltDB{DB: db}
 	svc := Service{
 		Feeds: []FeedInfo{
@@ -223,7 +228,7 @@ func TestService_DoIsAllowedFilter(t *testing.T) {
 		Store:           boltStore,
 		CheckDuration:   time.Millisecond * 500,
 		KeepPerChannel:  10,
-		RSSFileStore:    RSSFileStore{Enabled: true, Location: "/tmp"},
+		RSSFileStore:    RSSFileStore{Enabled: true, Location: tempDir},
 		DurationService: duration,
 	}
 
@@ -258,13 +263,13 @@ func TestService_DoIsAllowedFilter(t *testing.T) {
 	require.Equal(t, "vid2", downloader.GetCalls()[2].ID)
 	require.NotEmpty(t, downloader.GetCalls()[0].Fname)
 
-	rssData, err := os.ReadFile("/tmp/channel1.xml")
+	rssData, err := os.ReadFile(filepath.Join(tempDir, "channel1.xml")) //nolint:gosec // test file path
 	require.NoError(t, err)
 	t.Logf("%s", string(rssData))
 	assert.Contains(t, string(rssData), "<guid>channel1::vid2</guid>")
 	assert.Contains(t, string(rssData), "<itunes:duration>1234</itunes:duration>")
 
-	rssData, err = os.ReadFile("/tmp/channel2.xml")
+	rssData, err = os.ReadFile(filepath.Join(tempDir, "channel2.xml")) //nolint:gosec // test file path
 	require.NoError(t, err)
 	t.Logf("%s", string(rssData))
 	assert.Contains(t, string(rssData), "<guid>channel2::vid2</guid>")
@@ -272,9 +277,9 @@ func TestService_DoIsAllowedFilter(t *testing.T) {
 	assert.Contains(t, string(rssData), "<itunes:duration>1234</itunes:duration>")
 
 	require.Len(t, duration.FileCalls(), 3)
-	assert.Equal(t, "/tmp/4308c33c7ddb107c2d0c13a905e4c6962001bab4.mp3", duration.FileCalls()[0].Fname)
-	assert.Equal(t, "/tmp/3be877c750abb87daee80c005fe87e7a3f824fed.mp3", duration.FileCalls()[1].Fname)
-	assert.Equal(t, "/tmp/648f79b3a05ececb8a37600aa0aee332f0374e01.mp3", duration.FileCalls()[2].Fname)
+	assert.Equal(t, filepath.Join(tempDir, "4308c33c7ddb107c2d0c13a905e4c6962001bab4.mp3"), duration.FileCalls()[0].Fname)
+	assert.Equal(t, filepath.Join(tempDir, "3be877c750abb87daee80c005fe87e7a3f824fed.mp3"), duration.FileCalls()[1].Fname)
+	assert.Equal(t, filepath.Join(tempDir, "648f79b3a05ececb8a37600aa0aee332f0374e01.mp3"), duration.FileCalls()[2].Fname)
 }
 
 func TestService_RSSFeed(t *testing.T) {


### PR DESCRIPTION
### The build has been red on master since a4226be

`golangci-lint` v2.6.2, which is what the `version: v2.6` pin in the build workflow resolves to, reports the two bare `os.Remove(markerFile)` calls that came in with the startup update test:

```
app/youtube/service_test.go:37:3: G104: Errors unhandled (gosec)
app/youtube/service_test.go:59:3: G104: Errors unhandled (gosec)
```

The `.golangci.yml` exclusion covering `os.Remove` in test files is scoped to `errcheck`, so `gosec` still reports them; assigning to `_` clears it. Every run of the build workflow on master since 2026-03-19 has failed at that step, while the test step itself passes.

### A bolt file shared across packages

`TestProcessor_DoRemoveOldItems`, `TestProcessor_DoLoadMaxItems`, `TestProcessor_DoSkipItems` and `TestService_DoIsAllowedFilter` all opened `filepath.Join(os.TempDir(), "test.db")`, the same path in every package. `go test ./...` runs packages concurrently and none of these tests closed its `*bolt.DB`, so `app/proc` could hold the file while `app/youtube` blocked in `bolt.Open` until its timeout expired:

```
service_test.go:215: Received unexpected error: timeout
    Test: TestService_DoIsAllowedFilter
```

Each test now gets its own `t.TempDir()`, which also removes the need for the explicit `defer os.Remove(tmpfile)`. Every bolt handle in these two files is closed through `t.Cleanup`, which runs LIFO and therefore closes the database before the directory is removed.

`TestService_DoIsAllowedFilter` was also writing its downloads and both `channel1.xml` and `channel2.xml` into `/tmp` under fixed names and asserting on those paths. Those move under the same temp dir, the way `TestService_Do` already does it.

### A nil response dereference in `TestServer_Run`

The goroutine called `assert.NoError` on the result of `http.Get` and then closed the body unconditionally. `assert` records the failure and carries on, so when the server was not yet listening on the randomly chosen port the next line dereferenced a nil `*http.Response`:

```
panic: runtime error: invalid memory address or nil pointer dereference
goroutine 8 [running]:
github.com/umputun/feed-master/app/api.TestServer_Run.func1()
    app/api/server_test.go:34
```

A panic there takes down the whole `app/api` test binary, so one slow start reports as the entire package failing. `require` is not usable in a goroutine the test started, so the check returns early instead. The test also never waited for that goroutine, so on an early return from `Run` it could touch `t` after the test had finished; it now signals on a channel the test waits for, with a timeout on the request so the wait is bounded.

### Not covered here

The timing-dependent assertions in `app/youtube`, which fail for a different reason under load, need a decision on shape rather than a single obvious fix. Filed separately.
